### PR TITLE
Issue #15 fix

### DIFF
--- a/WWTExplorer3d/3dWIndow.cs
+++ b/WWTExplorer3d/3dWIndow.cs
@@ -13408,7 +13408,7 @@ namespace TerraViewer
                     if (target != SolarSystemObjects.Undefined)
                     {
                         trackingObject = place;
-                         double jumpTime = 4;
+                        double jumpTime = 4;
 
                         if (target == SolarSystemObjects.Custom)
                         {

--- a/WWTExplorer3d/3dWIndow.cs
+++ b/WWTExplorer3d/3dWIndow.cs
@@ -13408,12 +13408,7 @@ namespace TerraViewer
                     if (target != SolarSystemObjects.Undefined)
                     {
                         trackingObject = place;
-                        if (target == SolarSystemTrack && !(place.Classification == Classification.Star || place.Classification == Classification.Galaxy))
-                        {
-                            GotoTarget(place.CamParams, noZoom, instant);
-                            return;
-                        }
-                        double jumpTime = 4;
+                         double jumpTime = 4;
 
                         if (target == SolarSystemObjects.Custom)
                         {


### PR DESCRIPTION
This is a fix to Issue #15: In Solar System mode, clicking on the thumbnail of the object you're already centered on takes you to the Sun. 

Clicking on a target you are centered on now flies you to the default starting position for that target.