### PR TITLE
Introduce versioning for tour files

### DIFF
--- a/WWTExplorer3d/3dWIndow.cs
+++ b/WWTExplorer3d/3dWIndow.cs
@@ -15584,7 +15584,11 @@ namespace TerraViewer
                 {
                     LoadTourFromFile(filename, true, "");
                 }
-                catch
+                catch (UnsupportedTourFormatVersion exc)
+                {
+                    MessageBox.Show(Language.GetLocalizedText(1932, "This file was created by a newer version of WWT and cannot be read"), Language.GetLocalizedText(3, "Microsoft WorldWide Telescope"));
+                }
+                catch (Exception exc)
                 {
                     MessageBox.Show(Language.GetLocalizedText(102, "This file does not seem to be a valid tour"), Language.GetLocalizedText(3, "Microsoft WorldWide Telescope"));
                 }

--- a/WWTExplorer3d/3dWIndow.cs
+++ b/WWTExplorer3d/3dWIndow.cs
@@ -15584,11 +15584,11 @@ namespace TerraViewer
                 {
                     LoadTourFromFile(filename, true, "");
                 }
-                catch (UnsupportedTourFormatVersion exc)
+                catch (UnsupportedTourFormatVersion)
                 {
                     MessageBox.Show(Language.GetLocalizedText(1932, "This file was created by a newer version of WWT and cannot be read"), Language.GetLocalizedText(3, "Microsoft WorldWide Telescope"));
                 }
-                catch (Exception exc)
+                catch (Exception)
                 {
                     MessageBox.Show(Language.GetLocalizedText(102, "This file does not seem to be a valid tour"), Language.GetLocalizedText(3, "Microsoft WorldWide Telescope"));
                 }

--- a/WWTExplorer3d/Tour.cs
+++ b/WWTExplorer3d/Tour.cs
@@ -12,22 +12,27 @@ namespace TerraViewer
 
     public static class FormatOptions
     {
-      public const int FormatVersionMax = 1;
+        // The following variable indicates the current format version for tour files. This
+        // should be incremented if any backward-incompatible changes are made to tour files.
+        public const int CurrentFormatVersion = 1;
     }
 
 
     class UnsupportedTourFormatVersion : Exception
     {
 
-      public UnsupportedTourFormatVersion()
-      {
-      }
+        // This exception class is used to indicate when a tour file was produced with a
+        // version of WWT that is too recent.
 
-      public UnsupportedTourFormatVersion(int version)
-          : base(String.Format("Tour file has format version {0} but this version of WWT can only support format versions of {1} or lower", version, FormatOptions.FormatVersionMax))
-      {
+        public UnsupportedTourFormatVersion()
+        {
+        }
 
-      }
+        public UnsupportedTourFormatVersion(int version)
+            : base(String.Format("Tour file has format version {0} but this version of WWT can only support format versions of {1} or lower", version, FormatOptions.CurrentFormatVersion))
+        {
+        }
+
     }
 
 
@@ -158,6 +163,8 @@ namespace TerraViewer
 
             XmlNode root = doc["Tour"];
 
+            // The original format for tour files did not include version numbers, so
+            // we need to allow for this attribute to not exist.
             if (root.Attributes["FormatVersion"] != null)
             {
                 newTour.FormatVersion = int.Parse(root.Attributes["FormatVersion"].Value);
@@ -165,10 +172,15 @@ namespace TerraViewer
                 newTour.FormatVersion = 0;
             }
 
-            if (newTour.FormatVersion > FormatOptions.FormatVersionMax) {
+            // The current format used by this application is also assumed to be the
+            // most recent version that it can understand.
+            if (newTour.FormatVersion > FormatOptions.CurrentFormatVersion) {
                 throw new UnsupportedTourFormatVersion(newTour.FormatVersion);
             }
 
+            // When version numbers were added to tour files, the ID attribute was
+            // deliberately changed to Id so that new files would cause an error when
+            // read into old WWT instances (rather than give incorrect output).
             if (newTour.formatVersion == 0) {
                 newTour.id = root.Attributes["ID"].Value.ToString();
             } else {
@@ -452,7 +464,8 @@ namespace TerraViewer
                 xmlWriter.WriteProcessingInstruction("xml", "version='1.0' encoding='UTF-8'");
                 xmlWriter.WriteStartElement("Tour");
 
-                xmlWriter.WriteAttributeString("ID", this.id);
+                xmlWriter.WriteAttributeString("Id", this.id);
+                xmlWriter.WriteAttributeString("FormatVersion", FormatOptions.CurrentFormatVersion.ToString());
                 xmlWriter.WriteAttributeString("Title", this.title);
                 xmlWriter.WriteAttributeString("Descirption", this.Description);
                 xmlWriter.WriteAttributeString("Description", this.Description);


### PR DESCRIPTION
In the context of the discussion in https://github.com/WorldWideTelescope/wwt-web-client/pull/237 and https://github.com/WorldWideTelescope/wwt-web-client/pull/238 I thought it would be worthwhile investigating how we could start to version tour files today.

The solution I settled on is two-fold:

* Introduce the concept of a format version so that going forward we can raise nice errors if a file is too new. This is done with a ``FormatVersion`` XML attribute that is an integer starting at 1 (0 means pre-versioning)
* Make changes in the tour files so that old versions of WWT cannot read the file. This is done by changing the ``ID`` attribute to ``Id`` on the ``Tour`` element. In fact, the ``TourStop`` element uses ``Id`` not ``ID`` so this actually improves consistency (though that wasn't really the goal here).

If I try loading a Version 1 file (after this PR) in the current stable release of WWT, I get:

<img width="245" alt="Annotation 2019-09-03 160447" src="https://user-images.githubusercontent.com/314716/64190008-5687ac80-ce6d-11e9-9a64-c4766a1cf8ba.png">

If I update the version to 2 and try loading it in to the version of WWT in this PR I get:

<img width="356" alt="Annotation 2019-09-03 160349" src="https://user-images.githubusercontent.com/314716/64190047-67382280-ce6d-11e9-8a34-2ad45f2a583f.png">

While I agree that the error message for the old versions of WWT won't be very informative, there simply isn't a way to make it raise a nicer error as far as I can tell, but at least with this PR we can fix this for future.

We'll need to make sure we document properly changes/additions from one format version to the next, and keep the web client and desktop client functionality in sync.

If others think this is a good idea, I can set up a similar PR for the web client.


