### PR TITLE
Only hide eclipsed moons in realistic-lighting mode

### DIFF
--- a/WWTExplorer3d/Planets.cs
+++ b/WWTExplorer3d/Planets.cs
@@ -1255,7 +1255,13 @@ namespace TerraViewer
             Vector3d camera = new Vector3d(renderContext.CameraPosition);
             for (int planetId = 0; planetId < 14; planetId++)
             {
-                if (!planetLocations[planetId].Eclipsed)
+                // If we're using realistic lighting and this is an eclipsed
+                // moon, don't draw it at all. This is slightly suboptimal
+                // since, if you're looking at the moon, you'll suddenly be able
+                // to see the stars through it. In principle we should do
+                // something like keep on drawing it, but as an all-black
+                // sphere.
+                if (!(Settings.Active.SolarSystemLighting && planetLocations[planetId].Eclipsed))
                 {
                     Vector3d distVector = camera - (planet3dLocations[planetId] - centerPoint);
 


### PR DESCRIPTION
When SolarSystemLighting is off and everything is lit in flat fashion, it's jarring for Jupiter's moons to suddenly disappear as they orbit the planet.

Closes #8.

CC @patudom 