### PR TITLE
Fix a broken resource reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,11 @@ Most folks should download the official WWT releases here:
 
 You only need to clone this repository if you’re interested in hacking the
 source code to the WWT application yourself. If that describes you, WWT is a C#
-application buildable with Visual Studio 2018 or 2019.
+application buildable with Visual Studio 2018 or 2019. In order to build the
+installer, you’ll need to install the [Microsoft Visual Studio Installer
+Projects][mvsip] extension for Visual Studio.
+
+[mvsip]: https://marketplace.visualstudio.com/items?itemName=VisualStudioClient.MicrosoftVisualStudio2017InstallerProjects
 
 
 ## Getting involved

--- a/UwpRenderEngine/UwpRenderEngine.csproj
+++ b/UwpRenderEngine/UwpRenderEngine.csproj
@@ -2806,9 +2806,6 @@
     <Content Include="..\WWTExplorer3d\Resources\OpenCluster.jpg">
       <Link>Resources\OpenCluster.jpg</Link>
     </Content>
-    <Content Include="..\WWTExplorer3d\Resources\Pano Stitch small.png">
-      <Link>Resources\Pano Stitch small.png</Link>
-    </Content>
     <Content Include="..\WWTExplorer3d\Resources\PauseHS.png">
       <Link>Resources\PauseHS.png</Link>
     </Content>


### PR DESCRIPTION
UwpRenderEngine referenced a file that was deleted a while ago.

Also mention the installer extension in the README.