### PR TITLE
Move data cache location

### DIFF
--- a/MakeDataCabinetFile/Form1.cs
+++ b/MakeDataCabinetFile/Form1.cs
@@ -18,7 +18,7 @@ namespace MakeDataCabinetFile
 
         private void button1_Click(object sender, EventArgs e)
         {
-            string path = System.Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData) + "\\Microsoft\\WorldWideTelescope\\data";
+            string path = System.Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData) + "\\American Astronomical Society\\WorldWideTelescope\\data";
 
             FileCabinet cab = new FileCabinet(textBox1.Text, path);
 

--- a/WWTExplorer3d/3dWIndow.cs
+++ b/WWTExplorer3d/3dWIndow.cs
@@ -6263,7 +6263,7 @@ namespace TerraViewer
 
             if (string.IsNullOrEmpty(Properties.Settings.Default.CahceDirectory))
             {
-                Properties.Settings.Default.CahceDirectory = System.Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData) + "\\Microsoft\\WorldWideTelescope\\";
+                Properties.Settings.Default.CahceDirectory = System.Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData) + "\\American Astronomical Society\\WorldWideTelescope\\";
                 string tempString = Properties.Settings.Default.CahceDirectory;
             }
 
@@ -13183,7 +13183,7 @@ namespace TerraViewer
             {
                 try
                 {
-                    string path = System.Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData) + "\\Microsoft\\WorldWideTelescope";
+                    string path = System.Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData) + "\\American Astronomical Society\\WorldWideTelescope";
 
                     FileCabinet cab = new FileCabinet(saveDialog.FileName, Properties.Settings.Default.CahceDirectory);
 


### PR DESCRIPTION
This PR moves the cache directory from `Microsoft\WorldWideTelescope` to `American Astronomical Society\WorldWideTelescope`, and the data cabinet files to `American Astronomical Society\WorldWideTelescope\data` (all of these paths are relative to the user's local application data directory).