### PR TITLE
VOTable distances

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Set default behavior to automatically normalize line endings.
+* text=auto

--- a/WWTExplorer3d/SpreadSheetLayer.cs
+++ b/WWTExplorer3d/SpreadSheetLayer.cs
@@ -1263,7 +1263,7 @@ namespace TerraViewer
                         double alt = 1;
                         double altitude = 0;
                         double distParces = 0;
-                        double factor = GetScaleFactor(AltUnit, 1);
+                        double factor = UiTools.GetScaleFactor(AltUnit, 1);
                         if (altColumn == -1 || AltType == AltTypes.SeaLevel || bufferIsFlat)
                         {
                             alt = 1;
@@ -1338,7 +1338,7 @@ namespace TerraViewer
                         }
                         else if (this.CoordinatesType == CoordinatesTypes.Rectangular)
                         {
-                            double xyzScale = GetScaleFactor(CartesianScale, CartesianCustomScale) / meanRadius;
+                            double xyzScale = UiTools.GetScaleFactor(CartesianScale, CartesianCustomScale) / meanRadius;
 
                             if (ZAxisColumn > -1)
                             {
@@ -1982,48 +1982,6 @@ namespace TerraViewer
                 excelDate = 730000;
             }
             return new DateTime(1899, 12, 31).AddDays(excelDate);
-        }
-
-        public double GetScaleFactor(AltUnits AltUnit, double custom)
-        {
-            double factor = 1;
-
-            switch (AltUnit)
-            {
-                case AltUnits.Meters:
-                    factor = 1;
-                    break;
-                case AltUnits.Feet:
-                    factor = 1 * 0.3048;
-                    break;
-                case AltUnits.Inches:
-                    factor = (1.0 / 12.0) * 0.3048;
-                    break;
-                case AltUnits.Miles:
-                    factor = 5280 * 0.3048;
-                    break;
-                case AltUnits.Kilometers:
-                    factor = 1000;
-                    break;
-                case AltUnits.AstronomicalUnits:
-                    factor = 1000 * UiTools.KilometersPerAu;
-                    break;
-                case AltUnits.LightYears:
-                    factor = 1000 * UiTools.KilometersPerAu * UiTools.AuPerLightYear;
-                    break;
-                case AltUnits.Parsecs:
-                    factor = 1000 * UiTools.KilometersPerAu * UiTools.AuPerParsec;
-                    break;
-                case AltUnits.MegaParsecs:
-                    factor = 1000 * UiTools.KilometersPerAu * UiTools.AuPerParsec * 1000000;
-                    break;
-                case AltUnits.Custom:
-                    factor = custom;
-                    break;
-                default:
-                    break;
-            }
-            return factor;
         }
 
         public override IPlace FindClosest(Coordinates target, float distance, IPlace defaultPlace, bool astronomical)

--- a/WWTExplorer3d/UiTools.cs
+++ b/WWTExplorer3d/UiTools.cs
@@ -794,6 +794,51 @@ namespace TerraViewer
             return ((meters / 1000 / SSMUnitConversion) - 0.000001) / 4 * 9;
         }
 
+        public static AltUnits GetAltUnitFromAbbreviation(String abbr, AltUnits defaultValue = AltUnits.Meters)
+        {
+            if (abbr == "m")
+            {
+                return AltUnits.Meters;
+            }
+            else if (abbr == "ft")
+            {
+                return AltUnits.Feet;
+            }
+            else if (abbr == "in")
+            {
+                return AltUnits.Inches;
+            }
+            else if (abbr == "mi")
+            {
+                return AltUnits.Miles;
+            }
+            else if (abbr == "km")
+            {
+                return AltUnits.Kilometers;
+            }
+            else if (abbr == "au")
+            {
+                return AltUnits.AstronomicalUnits;
+            }
+            else if (abbr == "ly")
+            {
+                return AltUnits.LightYears;
+            }
+            else if (abbr == "pc")
+            {
+                return AltUnits.Parsecs;
+            }
+            else if (abbr == "mpc")
+            {
+                return AltUnits.Parsecs;
+            }
+            else
+            {
+                return defaultValue;
+            }
+ 
+        }
+
         public static string FormatDistancePlain(double distance)
         {
             if (distance < .0001)

--- a/WWTExplorer3d/UiTools.cs
+++ b/WWTExplorer3d/UiTools.cs
@@ -741,46 +741,51 @@ namespace TerraViewer
             return meters / SSMUnitConversion * UiTools.KilometersPerAu;
         }
 
-        public static double GetMeters(double distance, AltUnits units)
+        public static double GetScaleFactor(AltUnits AltUnit, double custom)
         {
-            double scaleFactor = 1.0;
+            double factor = 1;
 
-            switch (units)
+            switch (AltUnit)
             {
                 case AltUnits.Meters:
-                    scaleFactor = 1.0;
+                    factor = 1.0;
                     break;
                 case AltUnits.Feet:
-                    scaleFactor = 1.0 / 3.2808399;
+                    factor = 1.0 / 3.2808399;
                     break;
                 case AltUnits.Inches:
-                    scaleFactor = (1.0 / 3.2808399) / 12;
+                    factor = (1.0 / 3.2808399) / 12;
                     break;
                 case AltUnits.Miles:
-                    scaleFactor = 1609.344;
+                    factor = 1609.344;
                     break;
                 case AltUnits.Kilometers:
-                    scaleFactor = 1000;
+                    factor = 1000;
                     break;
                 case AltUnits.AstronomicalUnits:
-                    scaleFactor = UiTools.KilometersPerAu * 1000;
+                    factor = UiTools.KilometersPerAu * 1000;
                     break;
                 case AltUnits.LightYears:
-                    scaleFactor = UiTools.AuPerLightYear * UiTools.KilometersPerAu * 1000;
+                    factor = UiTools.AuPerLightYear * UiTools.KilometersPerAu * 1000;
                     break;
                 case AltUnits.Parsecs:
-                    scaleFactor = UiTools.AuPerParsec * UiTools.KilometersPerAu * 1000;
+                    factor = UiTools.AuPerParsec * UiTools.KilometersPerAu * 1000;
                     break;
                 case AltUnits.MegaParsecs:
-                    scaleFactor = UiTools.AuPerParsec * UiTools.KilometersPerAu * 1000 * 1000000;
+                    factor = UiTools.AuPerParsec * UiTools.KilometersPerAu * 1000 * 1000000;
                     break;
                 case AltUnits.Custom:
-                    scaleFactor = 1;
+                    factor = custom;
                     break;
                 default:
                     break;
             }
+            return factor;
+        }
 
+        public static double GetMeters(double distance, AltUnits units)
+        {
+            double scaleFactor = GetScaleFactor(units, 1);
             return distance * scaleFactor;
         }
 

--- a/WWTExplorer3d/UiTools.cs
+++ b/WWTExplorer3d/UiTools.cs
@@ -796,6 +796,7 @@ namespace TerraViewer
 
         public static AltUnits GetAltUnitFromAbbreviation(String abbr, AltUnits defaultValue = AltUnits.Meters)
         {
+            abbr = abbr.ToLower();
             if (abbr == "m")
             {
                 return AltUnits.Meters;

--- a/WWTExplorer3d/VOTableViewer.cs
+++ b/WWTExplorer3d/VOTableViewer.cs
@@ -363,7 +363,8 @@ namespace TerraViewer
         private void distanceSource_SelectionChanged(object sender, EventArgs e)
         {
             layer.AltColumn = distanceSource.SelectedIndex - 1;
-            layer.AltUnit = AltUnits.LightYears;
+            VoColumn altVoColumn = table.Column[layer.AltColumn];
+            layer.AltUnit = UiTools.GetAltUnitFromAbbreviation(altVoColumn.Unit, AltUnits.LightYears);
             layer.AltType = TimeSeriesLayer.AltTypes.Distance;
             layer.CleanUp();
         }

--- a/WWTExplorer3d/VoTableLayer.cs
+++ b/WWTExplorer3d/VoTableLayer.cs
@@ -208,7 +208,6 @@ namespace TerraViewer
                             double Zcoord = 0;
                             double alt = 1;
                             double altitude = 0;
-                            double distParces = 0;
                             double factor = GetScaleFactor(AltUnit, 1);
                             if (altColumn == -1 || AltType == AltTypes.SeaLevel || bufferIsFlat)
                             {
@@ -230,7 +229,6 @@ namespace TerraViewer
                                 if (astronomical)
                                 {
                                     factor = factor / (1000 * UiTools.KilometersPerAu);
-                                    distParces = (alt * factor) / UiTools.AuPerParsec;
 
                                     altitude = (factor * alt);
                                     alt = (factor * alt);
@@ -309,8 +307,6 @@ namespace TerraViewer
                             }
 
 
-                            //lastItem.Position = Coordinates.GeoTo3dDouble(Ycoord, Xcoord).Vector311;
-                            //positions.Add(lastItem.Position);
                             lastItem.Color = color;
                             if (sizeColumn > -1)
                             {
@@ -372,7 +368,6 @@ namespace TerraViewer
                                 lastItem.Tu = (float)SpaceTimeController.UtcToJulian(dateTime);
                                 lastItem.Tv = 0;
                             }
-
 
                             vertList.Add(lastItem);
                             currentIndex++;

--- a/WWTExplorer3d/VoTableLayer.cs
+++ b/WWTExplorer3d/VoTableLayer.cs
@@ -208,7 +208,7 @@ namespace TerraViewer
                             double Zcoord = 0;
                             double alt = 1;
                             double altitude = 0;
-                            double factor = GetScaleFactor(AltUnit, 1);
+                            double factor = UiTools.GetScaleFactor(AltUnit, 1);
                             if (altColumn == -1 || AltType == AltTypes.SeaLevel || bufferIsFlat)
                             {
                                 if (astronomical & !bufferIsFlat)
@@ -278,7 +278,7 @@ namespace TerraViewer
                             }
                             else if (this.CoordinatesType == CoordinatesTypes.Rectangular)
                             {
-                                double xyzScale = GetScaleFactor(CartesianScale, CartesianCustomScale) / meanRadius;
+                                double xyzScale = UiTools.GetScaleFactor(CartesianScale, CartesianCustomScale) / meanRadius;
 
                                 if (ZAxisColumn > -1)
                                 {
@@ -466,48 +466,6 @@ namespace TerraViewer
         {
             return table.GetColumnByUcd("vox:image.title") != null && table.GetColumnByUcd("VOX:Image.AccessReference") != null;
  
-        }
-
-        public double GetScaleFactor(AltUnits AltUnit, double custom)
-        {
-            double factor = 1;
-
-            switch (AltUnit)
-            {
-                case AltUnits.Meters:
-                    factor = 1;
-                    break;
-                case AltUnits.Feet:
-                    factor = 1 * 0.3048;
-                    break;
-                case AltUnits.Inches:
-                    factor = (1.0 / 12.0) * 0.3048;
-                    break;
-                case AltUnits.Miles:
-                    factor = 5280 * 0.3048;
-                    break;
-                case AltUnits.Kilometers:
-                    factor = 1000;
-                    break;
-                case AltUnits.AstronomicalUnits:
-                    factor = 1000 * UiTools.KilometersPerAu;
-                    break;
-                case AltUnits.LightYears:
-                    factor = 1000 * UiTools.KilometersPerAu * UiTools.AuPerLightYear;
-                    break;
-                case AltUnits.Parsecs:
-                    factor = 1000 * UiTools.KilometersPerAu * UiTools.AuPerParsec;
-                    break;
-                case AltUnits.MegaParsecs:
-                    factor = 1000 * UiTools.KilometersPerAu * UiTools.AuPerParsec * 1000000;
-                    break;
-                case AltUnits.Custom:
-                    factor = custom;
-                    break;
-                default:
-                    break;
-            }
-            return factor;
         }
 
         public override string[] Header


### PR DESCRIPTION
This PR adds support for properly using the distance/altitude coordinate to `VoTableLayer` so that these layers will display at the correct position in the sky in Solar System mode - currently, VOTable layers display their points at a radius of 1 AU from the Sun (see #178). Since `SpreadSheetLayer`s already support this, this is accomplished largely by mimicking the corresponding code inside that class. The relevant changes are in the `PrepVertexBuffer` method of `VoTableLayer`.

Related to this, when the distance column is set in the `VOTableViewer`, currently the unit is assumed to be light years. This PR changes that, using the unit for the relevant `VoColumn` (which is already parsed into the VoTable). To do this, I added a method in `UiTools` that grabs the appropriate `AltUnits` value based on the abbreviation given as the unit. Please let me know if there are any different/additional string representations that this should support.

One other thing worth mentioning:

* The code for this operation in `SpreadSheetLayer` used its method `GetScaleFactor`. As it was, this method had no real reason to be attached to `SpreadSheetLayer` - although not marked as static, it doesn't use any of the instance's member values. Since the calculation for `VoTableLayer` would require the same code, and this method was almost entirely identical to `UiTools.GetMeters`, I moved this function into `UiTools` and refactored `GetMeters` to use `GetScaleFactor`.