### PR TITLE
Fix issue with auto-hiding tabs

### DIFF
--- a/WWTExplorer3d/LayerManager.cs
+++ b/WWTExplorer3d/LayerManager.cs
@@ -2014,6 +2014,7 @@ namespace TerraViewer
             {
                 Earth3d.MainWindow.ShowLayersWindows = false;
             }
+            InsideLayerManagerRect = false;
             master = null;
         }
 


### PR DESCRIPTION
This PR fixes #111, which is that the Auto-Hide Tabs functionality does not if the LayerManager is closed via its close button.

The cause of the problem is the static variable `LayerManager.InsideLayerManagerRect`, which keeps track of whether or not the cursor position is within the layer manager. When the layer manager is closed, this variable no longer gets updated, so closing the layer manager using its close button (when `InsideLayerManagerRect` is `true`) means that the app continues to think that the mouse is over the layer manager. The fix in this PR is to set `InsideLayerManagerRect = false` when the layer manager is closed.