### PR TITLE
Units in trajectory reference frames

### DIFF
--- a/WWTExplorer3d/FrameWizardTrajectory.Designer.cs
+++ b/WWTExplorer3d/FrameWizardTrajectory.Designer.cs
@@ -73,6 +73,7 @@
             this.SemiMajorAxisUnits.State = TerraViewer.State.Rest;
             this.SemiMajorAxisUnits.TabIndex = 10;
             this.SemiMajorAxisUnits.Type = TerraViewer.WwtCombo.ComboType.List;
+            this.SemiMajorAxisUnits.SelectionChanged += new TerraViewer.SelectionChangedEventHandler(this.SemiMajorAxisUnits_SelectionChanged);
             // 
             // Import
             // 

--- a/WWTExplorer3d/FrameWizardTrajectory.Designer.cs
+++ b/WWTExplorer3d/FrameWizardTrajectory.Designer.cs
@@ -28,9 +28,10 @@
         /// </summary>
         private void InitializeComponent()
         {
+            System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(FrameWizardTrajectory));
             this.label1 = new System.Windows.Forms.Label();
             this.UnitsLabel = new System.Windows.Forms.Label();
-            this.SemiMajorAxisUnits = new TerraViewer.WwtCombo();
+            this.TrajectoryUnits = new TerraViewer.WwtCombo();
             this.Import = new TerraViewer.WwtButton();
             this.endDateRangeEdit = new System.Windows.Forms.TextBox();
             this.EndDateRangeLabel = new System.Windows.Forms.Label();
@@ -44,7 +45,7 @@
             this.label1.Name = "label1";
             this.label1.Size = new System.Drawing.Size(656, 38);
             this.label1.TabIndex = 0;
-            this.label1.Text = "Trajectory Reference Frames are based on a time series table of Julian Date/Times and heliocentric X,Y,Z coordinates in the referenced units. The reference frame will orient itself on the path described based on interpolating positions for the current time.";
+            this.label1.Text = resources.GetString("label1.Text");
             // 
             // UnitsLabel
             // 
@@ -55,25 +56,25 @@
             this.UnitsLabel.TabIndex = 9;
             this.UnitsLabel.Text = "Units";
             // 
-            // SemiMajorAxisUnits
+            // TrajectoryUnits
             // 
-            this.SemiMajorAxisUnits.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(20)))), ((int)(((byte)(23)))), ((int)(((byte)(31)))));
-            this.SemiMajorAxisUnits.DateTimeValue = new System.DateTime(2010, 7, 6, 14, 22, 50, 802);
-            this.SemiMajorAxisUnits.Filter = TerraViewer.Classification.Unfiltered;
-            this.SemiMajorAxisUnits.FilterStyle = false;
-            this.SemiMajorAxisUnits.Location = new System.Drawing.Point(154, 72);
-            this.SemiMajorAxisUnits.Margin = new System.Windows.Forms.Padding(0);
-            this.SemiMajorAxisUnits.MasterTime = true;
-            this.SemiMajorAxisUnits.MaximumSize = new System.Drawing.Size(248, 33);
-            this.SemiMajorAxisUnits.MinimumSize = new System.Drawing.Size(35, 33);
-            this.SemiMajorAxisUnits.Name = "SemiMajorAxisUnits";
-            this.SemiMajorAxisUnits.SelectedIndex = -1;
-            this.SemiMajorAxisUnits.SelectedItem = null;
-            this.SemiMajorAxisUnits.Size = new System.Drawing.Size(139, 33);
-            this.SemiMajorAxisUnits.State = TerraViewer.State.Rest;
-            this.SemiMajorAxisUnits.TabIndex = 10;
-            this.SemiMajorAxisUnits.Type = TerraViewer.WwtCombo.ComboType.List;
-            this.SemiMajorAxisUnits.SelectionChanged += new TerraViewer.SelectionChangedEventHandler(this.SemiMajorAxisUnits_SelectionChanged);
+            this.TrajectoryUnits.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(20)))), ((int)(((byte)(23)))), ((int)(((byte)(31)))));
+            this.TrajectoryUnits.DateTimeValue = new System.DateTime(2010, 7, 6, 14, 22, 50, 802);
+            this.TrajectoryUnits.Filter = TerraViewer.Classification.Unfiltered;
+            this.TrajectoryUnits.FilterStyle = false;
+            this.TrajectoryUnits.Location = new System.Drawing.Point(154, 72);
+            this.TrajectoryUnits.Margin = new System.Windows.Forms.Padding(0);
+            this.TrajectoryUnits.MasterTime = true;
+            this.TrajectoryUnits.MaximumSize = new System.Drawing.Size(248, 33);
+            this.TrajectoryUnits.MinimumSize = new System.Drawing.Size(35, 33);
+            this.TrajectoryUnits.Name = "TrajectoryUnits";
+            this.TrajectoryUnits.SelectedIndex = -1;
+            this.TrajectoryUnits.SelectedItem = null;
+            this.TrajectoryUnits.Size = new System.Drawing.Size(139, 33);
+            this.TrajectoryUnits.State = TerraViewer.State.Rest;
+            this.TrajectoryUnits.TabIndex = 10;
+            this.TrajectoryUnits.Type = TerraViewer.WwtCombo.ComboType.List;
+            this.TrajectoryUnits.SelectionChanged += new TerraViewer.SelectionChangedEventHandler(this.TrajectoryUnits_SelectionChanged);
             // 
             // Import
             // 
@@ -138,7 +139,7 @@
             this.Controls.Add(this.beginDateRangeLabel);
             this.Controls.Add(this.Import);
             this.Controls.Add(this.UnitsLabel);
-            this.Controls.Add(this.SemiMajorAxisUnits);
+            this.Controls.Add(this.TrajectoryUnits);
             this.Controls.Add(this.label1);
             this.Name = "FrameWizardTrajectory";
             this.Load += new System.EventHandler(this.FrameWizardTrajectory_Load);
@@ -151,7 +152,7 @@
 
         private System.Windows.Forms.Label label1;
         private System.Windows.Forms.Label UnitsLabel;
-        private WwtCombo SemiMajorAxisUnits;
+        private WwtCombo TrajectoryUnits;
         private WwtButton Import;
         private System.Windows.Forms.TextBox endDateRangeEdit;
         private System.Windows.Forms.Label EndDateRangeLabel;

--- a/WWTExplorer3d/FrameWizardTrajectory.cs
+++ b/WWTExplorer3d/FrameWizardTrajectory.cs
@@ -71,6 +71,11 @@ namespace TerraViewer
                     UiTools.ShowMessageBox(Language.GetLocalizedText(947, "The File does not appear to be a Vaild Trajectory File."), Language.GetLocalizedText(3, "Microsoft WorldWide Telescope"));
                 }
             }
-        } 
+        }
+
+        private void SemiMajorAxisUnits_SelectionChanged(object sender, EventArgs e)
+        {
+            frame.SemiMajorAxisUnits = (AltUnits)SemiMajorAxisUnits.SelectedIndex;
+        }
     }
 }

--- a/WWTExplorer3d/FrameWizardTrajectory.cs
+++ b/WWTExplorer3d/FrameWizardTrajectory.cs
@@ -38,10 +38,8 @@ namespace TerraViewer
 
         private void FrameWizardTrajectory_Load(object sender, EventArgs e)
         {
-            SemiMajorAxisUnits.Items.AddRange(Enum.GetNames(typeof(AltUnits)));
-            SemiMajorAxisUnits.SelectedIndex = (int)frame.SemiMajorAxisUnits;
-
-
+            TrajectoryUnits.Items.AddRange(Enum.GetNames(typeof(AltUnits)));
+            TrajectoryUnits.SelectedIndex = (int)frame.TrajectoryUnits;
         }
 
         private void Import_Click(object sender, EventArgs e)
@@ -73,9 +71,9 @@ namespace TerraViewer
             }
         }
 
-        private void SemiMajorAxisUnits_SelectionChanged(object sender, EventArgs e)
+        private void TrajectoryUnits_SelectionChanged(object sender, EventArgs e)
         {
-            frame.SemiMajorAxisUnits = (AltUnits)SemiMajorAxisUnits.SelectedIndex;
+            frame.TrajectoryUnits = (AltUnits)TrajectoryUnits.SelectedIndex;
         }
     }
 }

--- a/WWTExplorer3d/FrameWizardTrajectory.resx
+++ b/WWTExplorer3d/FrameWizardTrajectory.resx
@@ -112,9 +112,12 @@
     <value>2.0</value>
   </resheader>
   <resheader name="reader">
-    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <resheader name="writer">
-    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="label1.Text" xml:space="preserve">
+    <value>Trajectory Reference Frames are based on a time series table of Julian Date/Times and heliocentric X,Y,Z coordinates in the referenced units. The reference frame will orient itself on the path described based on interpolating positions for the current time.</value>
+  </data>
 </root>

--- a/WWTExplorer3d/LayerManagerCore.cs
+++ b/WWTExplorer3d/LayerManagerCore.cs
@@ -1440,8 +1440,8 @@ namespace TerraViewer
                         }
                         else if (map.Frame.ReferenceFrameType == ReferenceFrameTypes.Trajectory)
                         {
-                            //if (map.Frame.trajectoryLines == null)
-                            //{
+                            if (map.Frame.trajectoryLines == null || map.Frame.trajectoryDirty)
+                            {
                                 map.Frame.trajectoryLines = new LineList();
                                 map.Frame.trajectoryLines.ShowFarSide = true;
                                 map.Frame.trajectoryLines.UseNonRotatingFrame = true;
@@ -1455,7 +1455,8 @@ namespace TerraViewer
                                     pos2.Multiply(1 / renderContext.NominalRadius);
                                     map.Frame.trajectoryLines.AddLine(pos1, pos2, map.Frame.RepresentativeColor, new Dates());
                                 }
-                            //}
+                                map.Frame.trajectoryDirty = false;
+                            }
                             Matrix3d matSaved = renderContext.World;
                             renderContext.World = thisMap.Frame.WorldMatrix * renderContext.WorldBaseNonRotating;
                             double distss = UiTools.SolarSystemToMeters(RenderEngine.Engine.SolarSystemCameraDistance);

--- a/WWTExplorer3d/LayerManagerCore.cs
+++ b/WWTExplorer3d/LayerManagerCore.cs
@@ -1395,7 +1395,7 @@ namespace TerraViewer
                         {
                             if (map.Frame.Orbit == null)
                             {
-                                map.Frame.Orbit = new Orbit(map.Frame.Elements, 360, map.Frame.RepresentativeColor, 1,/* referenceFrame == "Sun" ? (float)(UiTools.KilometersPerAu*1000.0):*/ (float)renderContext.NominalRadius);
+                                map.Frame.Orbit = new Orbit(map.Frame.Elements, 360, map.Frame.RepresentativeColor, (float)ReferenceFrame.GetScaleFactor(map.Frame.SemiMajorAxisUnits, 1),/* referenceFrame == "Sun" ? (float)(UiTools.KilometersPerAu*1000.0):*/ (float)renderContext.NominalRadius);
                             }
 
                             double dd = renderContext.NominalRadius;
@@ -1440,8 +1440,8 @@ namespace TerraViewer
                         }
                         else if (map.Frame.ReferenceFrameType == ReferenceFrameTypes.Trajectory)
                         {
-                            if (map.Frame.trajectoryLines == null)
-                            {
+                            //if (map.Frame.trajectoryLines == null)
+                            //{
                                 map.Frame.trajectoryLines = new LineList();
                                 map.Frame.trajectoryLines.ShowFarSide = true;
                                 map.Frame.trajectoryLines.UseNonRotatingFrame = true;
@@ -1455,7 +1455,7 @@ namespace TerraViewer
                                     pos2.Multiply(1 / renderContext.NominalRadius);
                                     map.Frame.trajectoryLines.AddLine(pos1, pos2, map.Frame.RepresentativeColor, new Dates());
                                 }
-                            }
+                            //}
                             Matrix3d matSaved = renderContext.World;
                             renderContext.World = thisMap.Frame.WorldMatrix * renderContext.WorldBaseNonRotating;
                             double distss = UiTools.SolarSystemToMeters(RenderEngine.Engine.SolarSystemCameraDistance);

--- a/WWTExplorer3d/LayerManagerCore.cs
+++ b/WWTExplorer3d/LayerManagerCore.cs
@@ -1395,7 +1395,7 @@ namespace TerraViewer
                         {
                             if (map.Frame.Orbit == null)
                             {
-                                map.Frame.Orbit = new Orbit(map.Frame.Elements, 360, map.Frame.RepresentativeColor, (float)ReferenceFrame.GetScaleFactor(map.Frame.SemiMajorAxisUnits, 1),/* referenceFrame == "Sun" ? (float)(UiTools.KilometersPerAu*1000.0):*/ (float)renderContext.NominalRadius);
+                                map.Frame.Orbit = new Orbit(map.Frame.Elements, 360, map.Frame.RepresentativeColor, (float)UiTools.GetScaleFactor(map.Frame.SemiMajorAxisUnits, 1),/* referenceFrame == "Sun" ? (float)(UiTools.KilometersPerAu*1000.0):*/ (float)renderContext.NominalRadius);
                             }
 
                             double dd = renderContext.NominalRadius;

--- a/WWTExplorer3d/LayerManagerCore.cs
+++ b/WWTExplorer3d/LayerManagerCore.cs
@@ -1447,10 +1447,11 @@ namespace TerraViewer
                                 map.Frame.trajectoryLines.UseNonRotatingFrame = true;
 
                                 int count = map.Frame.Trajectory.Count - 1;
+                                AltUnits units = map.Frame.TrajectoryUnits;
                                 for (int i = 0; i < count; i++)
                                 {
-                                    Vector3d pos1 = map.Frame.Trajectory[i].Position;
-                                    Vector3d pos2 = map.Frame.Trajectory[i + 1].Position;
+                                    Vector3d pos1 = map.Frame.Trajectory[i].Position(units);
+                                    Vector3d pos2 = map.Frame.Trajectory[i + 1].Position(units);
                                     pos1.Multiply(1 / renderContext.NominalRadius);
                                     pos2.Multiply(1 / renderContext.NominalRadius);
                                     map.Frame.trajectoryLines.AddLine(pos1, pos2, map.Frame.RepresentativeColor, new Dates());

--- a/WWTExplorer3d/ReferenceFrame.cs
+++ b/WWTExplorer3d/ReferenceFrame.cs
@@ -302,12 +302,12 @@ namespace TerraViewer
                 if (semiMajorAxisUnits != value)
                 {
                     semiMajorAxisUnits = value;
-                    //Scale = ReferenceFrame.GetScaleFactor(semiMajorAxisUnits, 1);
                     if (referenceFrameType == ReferenceFrameTypes.Trajectory)
                     {
                         foreach (TrajectorySample sample in Trajectory) {
                             sample.Unit = semiMajorAxisUnits;
                         }
+                        trajectoryDirty = true;
                     }   
                 }
                 
@@ -381,6 +381,7 @@ namespace TerraViewer
             set { orbit = value; }
         }
         public LineList trajectoryLines = null;
+        public bool trajectoryDirty = false;
         CAAEllipticalObjectElements elements = new CAAEllipticalObjectElements();
 
 

--- a/WWTExplorer3d/ReferenceFrame.cs
+++ b/WWTExplorer3d/ReferenceFrame.cs
@@ -256,19 +256,28 @@ namespace TerraViewer
         public AltUnits SemiMajorAxisUnits
         {
             get { return semiMajorAxisUnits; }
-            set {
-                if (semiMajorAxisUnits != value)
+            set { semiMajorAxisUnits = value; }
+        }
+        public AltUnits trajectoryUnits = AltUnits.Meters;
+
+        [LayerProperty]
+        public AltUnits TrajectoryUnits
+        {
+            get { return trajectoryUnits; }
+            set
+            {
+                if (trajectoryUnits != value)
                 {
-                    semiMajorAxisUnits = value;
+                    trajectoryUnits = value;
                     if (referenceFrameType == ReferenceFrameTypes.Trajectory)
                     {
-                        foreach (TrajectorySample sample in Trajectory) {
-                            sample.Unit = semiMajorAxisUnits;
+                        foreach (TrajectorySample sample in Trajectory)
+                        {
+                            sample.Unit = trajectoryUnits;
                         }
                         trajectoryDirty = true;
-                    }   
+                    }
                 }
-                
             }
         }
         public double eccentricity; // e
@@ -400,8 +409,7 @@ namespace TerraViewer
 
             if (ReferenceFrameType == ReferenceFrameTypes.Trajectory)
             {
-                xmlWriter.WriteAttributeString("SemiMajorAxis", SemiMajorAxis.ToString());
-                xmlWriter.WriteAttributeString("SemiMajorAxisScale", this.SemiMajorAxisUnits.ToString());
+                xmlWriter.WriteAttributeString("TrajectoryUnits", this.TrajectoryUnits.ToString());
                 xmlWriter.WriteStartElement("Trajectory");
 
                 foreach (TrajectorySample sample in Trajectory)
@@ -423,15 +431,6 @@ namespace TerraViewer
             ReferenceFrameType = (ReferenceFrameTypes)Enum.Parse(typeof(ReferenceFrameTypes), node.Attributes["ReferenceFrameType"].Value);
 
             Reference = (ReferenceFrames)Enum.Parse(typeof(ReferenceFrames), node.Attributes["Reference"].Value);
-
-            if (node.Attributes["SemiMajorAxis"] != null)
-            {
-                SemiMajorAxis = Double.Parse(node.Attributes["SemiMajorAxis"].Value);
-            }
-            if (node.Attributes["SemiMajorAxisScale"] != null)
-            {
-                SemiMajorAxisUnits = (AltUnits)Enum.Parse(typeof(AltUnits), node.Attributes["SemiMajorAxisScale"].Value);
-            }
 
             ParentsRoationalBase = Boolean.Parse(node.Attributes["ParentsRoationalBase"].Value);
             MeanRadius = Double.Parse(node.Attributes["MeanRadius"].Value);
@@ -483,6 +482,10 @@ namespace TerraViewer
                     {
                         Trajectory.Add(new TrajectorySample(child.InnerText, SemiMajorAxisUnits));
                     }
+                }
+                if (node.Attributes["TrajectoryUnits"] != null)
+                {
+                    TrajectoryUnits = (AltUnits)Enum.Parse(typeof(AltUnits), node.Attributes["TrajectoryUnits"].Value);
                 }
             }
 

--- a/WWTExplorer3d/ReferenceFrame.cs
+++ b/WWTExplorer3d/ReferenceFrame.cs
@@ -360,7 +360,7 @@ namespace TerraViewer
             string[] data = File.ReadAllLines(filename);
             foreach (string line in data)
             {
-                Trajectory.Add(new TrajectorySample(line, semiMajorAxisUnits));
+                Trajectory.Add(new TrajectorySample(line, TrajectoryUnits));
             }
         }
 

--- a/WWTExplorer3d/ReferenceFrame.cs
+++ b/WWTExplorer3d/ReferenceFrame.cs
@@ -28,48 +28,6 @@ namespace TerraViewer
         // Serialized
         public string name;
 
-        public static double GetScaleFactor(AltUnits AltUnit, double custom)
-        {
-            double factor = 1;
-
-            switch (AltUnit)
-            {
-                case AltUnits.Meters:
-                    factor = 1;
-                    break;
-                case AltUnits.Feet:
-                    factor = 1 * 0.3048;
-                    break;
-                case AltUnits.Inches:
-                    factor = (1.0 / 12.0) * 0.3048;
-                    break;
-                case AltUnits.Miles:
-                    factor = 5280 * 0.3048;
-                    break;
-                case AltUnits.Kilometers:
-                    factor = 1000;
-                    break;
-                case AltUnits.AstronomicalUnits:
-                    factor = 1000 * UiTools.KilometersPerAu;
-                    break;
-                case AltUnits.LightYears:
-                    factor = 1000 * UiTools.KilometersPerAu * UiTools.AuPerLightYear;
-                    break;
-                case AltUnits.Parsecs:
-                    factor = 1000 * UiTools.KilometersPerAu * UiTools.AuPerParsec;
-                    break;
-                case AltUnits.MegaParsecs:
-                    factor = 1000 * UiTools.KilometersPerAu * UiTools.AuPerParsec * 1000000;
-                    break;
-                case AltUnits.Custom:
-                    factor = custom;
-                    break;
-                default:
-                    break;
-            }
-            return factor;
-        }
-
         [LayerProperty]
         public string Name
         {
@@ -1323,7 +1281,7 @@ namespace TerraViewer
             set
             {
                 unit = value;
-                factor = ReferenceFrame.GetScaleFactor(unit, 1);
+                factor = UiTools.GetScaleFactor(unit, 1);
             }
         }
 


### PR DESCRIPTION
This PR adds support for different units in trajectory reference frames. There are a few different parts to this PR:

* In the `FrameWizardTrajectory` window, the units dropdown currently doesn't actually trigger anything. This PR adds a listener that will change the `TrajectoryUnits` of the associated reference frame when the dropdown changes.
* `TrajectorySample` currently has a hard-coded factor of 1000 when returning its `Position`. This PR gives each `TrajectorySample` a unit type, and the appropriate factor is used when returning the position.
* When a trajectory reference frame has its units change, its trajectory is marked as 'dirty', so that the layer manager knows that the orbit needs to be redrawn.