### PR TITLE
Units in fixed spherical reference frames

### DIFF
--- a/WWTExplorer3d/FrameWizardPosition.Designer.cs
+++ b/WWTExplorer3d/FrameWizardPosition.Designer.cs
@@ -111,7 +111,7 @@
             this.GetFromView.DialogResult = System.Windows.Forms.DialogResult.None;
             this.GetFromView.ImageDisabled = null;
             this.GetFromView.ImageEnabled = null;
-            this.GetFromView.Location = new System.Drawing.Point(380, 121);
+            this.GetFromView.Location = new System.Drawing.Point(94, 190);
             this.GetFromView.MaximumSize = new System.Drawing.Size(140, 33);
             this.GetFromView.Name = "GetFromView";
             this.GetFromView.Selected = false;

--- a/WWTExplorer3d/FrameWizardPosition.Designer.cs
+++ b/WWTExplorer3d/FrameWizardPosition.Designer.cs
@@ -36,6 +36,8 @@
             this.LatitudeLabel = new System.Windows.Forms.Label();
             this.label3 = new System.Windows.Forms.Label();
             this.GetFromView = new TerraViewer.WwtButton();
+            this.AltitudeUnitsLabel = new System.Windows.Forms.Label();
+            this.AltitudeUnits = new TerraViewer.WwtCombo();
             this.SuspendLayout();
             // 
             // Altitude
@@ -73,9 +75,9 @@
             this.altDepthLabel.AutoSize = true;
             this.altDepthLabel.Location = new System.Drawing.Point(192, 85);
             this.altDepthLabel.Name = "altDepthLabel";
-            this.altDepthLabel.Size = new System.Drawing.Size(83, 13);
+            this.altDepthLabel.Size = new System.Drawing.Size(42, 13);
             this.altDepthLabel.TabIndex = 23;
-            this.altDepthLabel.Text = "Altitude (Meters)";
+            this.altDepthLabel.Text = "Altitude";
             // 
             // LongitudeLabel
             // 
@@ -109,7 +111,7 @@
             this.GetFromView.DialogResult = System.Windows.Forms.DialogResult.None;
             this.GetFromView.ImageDisabled = null;
             this.GetFromView.ImageEnabled = null;
-            this.GetFromView.Location = new System.Drawing.Point(195, 144);
+            this.GetFromView.Location = new System.Drawing.Point(380, 121);
             this.GetFromView.MaximumSize = new System.Drawing.Size(140, 33);
             this.GetFromView.Name = "GetFromView";
             this.GetFromView.Selected = false;
@@ -118,10 +120,41 @@
             this.GetFromView.Text = "Get From View";
             this.GetFromView.Click += new System.EventHandler(this.GetFromView_Click);
             // 
+            // AltitudeUnitsLabel
+            // 
+            this.AltitudeUnitsLabel.AutoSize = true;
+            this.AltitudeUnitsLabel.Location = new System.Drawing.Point(192, 141);
+            this.AltitudeUnitsLabel.Name = "AltitudeUnitsLabel";
+            this.AltitudeUnitsLabel.Size = new System.Drawing.Size(69, 13);
+            this.AltitudeUnitsLabel.TabIndex = 29;
+            this.AltitudeUnitsLabel.Text = "Altitude Units";
+            // 
+            // AltitudeUnits
+            // 
+            this.AltitudeUnits.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(20)))), ((int)(((byte)(23)))), ((int)(((byte)(31)))));
+            this.AltitudeUnits.DateTimeValue = new System.DateTime(2010, 7, 6, 14, 22, 50, 802);
+            this.AltitudeUnits.Filter = TerraViewer.Classification.Unfiltered;
+            this.AltitudeUnits.FilterStyle = false;
+            this.AltitudeUnits.Location = new System.Drawing.Point(195, 154);
+            this.AltitudeUnits.Margin = new System.Windows.Forms.Padding(0);
+            this.AltitudeUnits.MasterTime = true;
+            this.AltitudeUnits.MaximumSize = new System.Drawing.Size(248, 33);
+            this.AltitudeUnits.MinimumSize = new System.Drawing.Size(35, 33);
+            this.AltitudeUnits.Name = "AltitudeUnits";
+            this.AltitudeUnits.SelectedIndex = -1;
+            this.AltitudeUnits.SelectedItem = null;
+            this.AltitudeUnits.Size = new System.Drawing.Size(139, 33);
+            this.AltitudeUnits.State = TerraViewer.State.Rest;
+            this.AltitudeUnits.TabIndex = 30;
+            this.AltitudeUnits.Type = TerraViewer.WwtCombo.ComboType.List;
+            this.AltitudeUnits.SelectionChanged += new TerraViewer.SelectionChangedEventHandler(this.AltitudeUnits_SelectionChanged);
+            // 
             // FrameWizardPosition
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.Controls.Add(this.AltitudeUnits);
+            this.Controls.Add(this.AltitudeUnitsLabel);
             this.Controls.Add(this.GetFromView);
             this.Controls.Add(this.Altitude);
             this.Controls.Add(this.Longitude);
@@ -147,5 +180,7 @@
         private System.Windows.Forms.Label LatitudeLabel;
         private System.Windows.Forms.Label label3;
         private WwtButton GetFromView;
+        private System.Windows.Forms.Label AltitudeUnitsLabel;
+        private WwtCombo AltitudeUnits;
     }
 }

--- a/WWTExplorer3d/FrameWizardPosition.cs
+++ b/WWTExplorer3d/FrameWizardPosition.cs
@@ -18,28 +18,25 @@ namespace TerraViewer
 
         private void SetUiStrings()
         {
-            this.altDepthLabel.Text = Language.GetLocalizedText(802, "Altitude");
+            this.altDepthLabel.Text = Language.GetLocalizedText(763, "Altitude");
             this.LongitudeLabel.Text = Language.GetLocalizedText(803, "Longitude (Decimal Degrees)");
             this.LatitudeLabel.Text = Language.GetLocalizedText(804, "Latitude (Decimal Degrees)");
             this.label3.Text = Language.GetLocalizedText(801, "Select the Latitude, Longitude and Altitude");
             this.GetFromView.Text = Language.GetLocalizedText(259, "Get From View");
         }
 
-        private void SetVisibilities()
-        {
-            if (this.frame.ReferenceFrameType == ReferenceFrameTypes.Synodic)
-            {
-                this.AltitudeUnitsLabel.Visible = false;
-                this.AltitudeUnits.Visible = false;
-            }
-        }
-
         ReferenceFrame frame = null;
         public override void SetData(object data)
         {
             frame = data as ReferenceFrame;
-            SetVisibilities();
+            if (this.frame.ReferenceFrameType == ReferenceFrameTypes.Synodic)
+            {
+                this.AltitudeUnitsLabel.Visible = false;
+                this.AltitudeUnits.Visible = false;
+                this.altDepthLabel.Text = Language.GetLocalizedText(802, "Altitude (Meters)");
+            }
         }
+
         public override bool Save()
         {
             bool failed = false;

--- a/WWTExplorer3d/FrameWizardPosition.cs
+++ b/WWTExplorer3d/FrameWizardPosition.cs
@@ -18,7 +18,7 @@ namespace TerraViewer
 
         private void SetUiStrings()
         {
-            this.altDepthLabel.Text = Language.GetLocalizedText(802, "Altitude (Meters)");
+            this.altDepthLabel.Text = Language.GetLocalizedText(802, "Altitude");
             this.LongitudeLabel.Text = Language.GetLocalizedText(803, "Longitude (Decimal Degrees)");
             this.LatitudeLabel.Text = Language.GetLocalizedText(804, "Latitude (Decimal Degrees)");
             this.label3.Text = Language.GetLocalizedText(801, "Select the Latitude, Longitude and Altitude");
@@ -48,7 +48,8 @@ namespace TerraViewer
             Longitude.Text = frame.Lng.ToString();
             Altitude.Text = frame.Altitude.ToString();
 
-
+            AltitudeUnits.Items.AddRange(Enum.GetNames(typeof(AltUnits)));
+            AltitudeUnits.SelectedIndex = (int)frame.AltUnits;
         }
 
         private void GetFromView_Click(object sender, EventArgs e)
@@ -59,6 +60,11 @@ namespace TerraViewer
             Lattitude.Text = Coordinates.FormatDMS(point.Y);
             Longitude.Text = Coordinates.FormatDMS(point.X);
             Altitude.Text = RenderEngine.Engine.GetEarthAltitude().ToString();
+        }
+
+        private void AltitudeUnits_SelectionChanged(object sender, EventArgs e)
+        {
+            frame.AltUnits = (AltUnits)AltitudeUnits.SelectedIndex;
         }
     }
 }

--- a/WWTExplorer3d/FrameWizardPosition.cs
+++ b/WWTExplorer3d/FrameWizardPosition.cs
@@ -25,10 +25,20 @@ namespace TerraViewer
             this.GetFromView.Text = Language.GetLocalizedText(259, "Get From View");
         }
 
+        private void SetVisibilities()
+        {
+            if (this.frame.ReferenceFrameType == ReferenceFrameTypes.Synodic)
+            {
+                this.AltitudeUnitsLabel.Visible = false;
+                this.AltitudeUnits.Visible = false;
+            }
+        }
+
         ReferenceFrame frame = null;
         public override void SetData(object data)
         {
             frame = data as ReferenceFrame;
+            SetVisibilities();
         }
         public override bool Save()
         {
@@ -37,6 +47,14 @@ namespace TerraViewer
             frame.Lat = ParseAndValidateCoordinate(Lattitude, frame.Lat, ref failed);
             frame.Lng = ParseAndValidateCoordinate(Longitude, frame.Lng, ref failed);
             frame.Altitude = ParseAndValidateDouble(Altitude, frame.Altitude, ref failed);
+            try
+            {
+                frame.AltUnits = (AltUnits)Enum.Parse(typeof(AltUnits), AltitudeUnits.SelectedItem.ToString());
+            }
+            catch
+            {
+                failed = true;
+            }
          
             return !failed;
 

--- a/WWTExplorer3d/FrameWizardPosition.resx
+++ b/WWTExplorer3d/FrameWizardPosition.resx
@@ -112,9 +112,9 @@
     <value>2.0</value>
   </resheader>
   <resheader name="reader">
-    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <resheader name="writer">
-    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
 </root>

--- a/WWTExplorer3d/ReferenceFrame.cs
+++ b/WWTExplorer3d/ReferenceFrame.cs
@@ -158,7 +158,14 @@ namespace TerraViewer
             get { return altitude; }
             set { altitude = value; }
         }
+        public AltUnits altUnits;
 
+        [LayerProperty]
+        public AltUnits AltUnits
+        {
+            get { return altUnits; }
+            set { altUnits = value; }
+        }
 
         // For Rotating frames
         public double rotationalPeriod; // Days
@@ -362,6 +369,7 @@ namespace TerraViewer
                 xmlWriter.WriteAttributeString("Lat", Lat.ToString());
                 xmlWriter.WriteAttributeString("Lng", Lng.ToString());
                 xmlWriter.WriteAttributeString("Altitude", Altitude.ToString());
+                xmlWriter.WriteAttributeString("AltUnits", AltUnits.ToString());
             }
             xmlWriter.WriteAttributeString("RotationalPeriod", RotationalPeriod.ToString());
             xmlWriter.WriteAttributeString("ZeroRotationDate", ZeroRotationDate.ToString());
@@ -422,6 +430,14 @@ namespace TerraViewer
                 Lat = Double.Parse(node.Attributes["Lat"].Value);
                 Lng = Double.Parse(node.Attributes["Lng"].Value);
                 Altitude = Double.Parse(node.Attributes["Altitude"].Value);
+                if (node.Attributes["AltUnits"].Value != null)
+                {
+                    AltUnits = (AltUnits)Enum.Parse(typeof(AltUnits), node.Attributes["AltUnits"].Value);
+                }
+                else
+                {
+                    AltUnits = AltUnits.Meters;
+                }
             }
 
             RotationalPeriod = Double.Parse(node.Attributes["RotationalPeriod"].Value);
@@ -722,6 +738,7 @@ namespace TerraViewer
                 Lat = SpaceTimeController.Location.Lat;
                 Lng = SpaceTimeController.Location.Lng;
                 Altitude = SpaceTimeController.Altitude;
+                AltUnits = AltUnits.Meters;
             }
 
 
@@ -737,7 +754,8 @@ namespace TerraViewer
                 double rotationCurrent = (((SpaceTimeController.JNow - this.ZeroRotationDate) / RotationalPeriod) * Math.PI * 2) % (Math.PI * 2);
                 WorldMatrix.Multiply(Matrix3d.RotationX(-rotationCurrent));
             }
-            WorldMatrix.Translate(new Vector3d(1 + (Altitude / renderContext.NominalRadius), 0, 0));
+            double altFactor = UiTools.GetScaleFactor(AltUnits, 1);
+            WorldMatrix.Translate(new Vector3d(1 + (Altitude * altFactor / renderContext.NominalRadius), 0, 0));
             WorldMatrix.Multiply(Matrix3d.RotationZ(Lat / 180 * Math.PI));
             WorldMatrix.Multiply(Matrix3d.RotationY(-(Lng) / 180 * Math.PI));
         }

--- a/WWTExplorer3d/ReferenceFrame.cs
+++ b/WWTExplorer3d/ReferenceFrame.cs
@@ -430,13 +430,9 @@ namespace TerraViewer
                 Lat = Double.Parse(node.Attributes["Lat"].Value);
                 Lng = Double.Parse(node.Attributes["Lng"].Value);
                 Altitude = Double.Parse(node.Attributes["Altitude"].Value);
-                if (node.Attributes["AltUnits"].Value != null)
+                if (node.Attributes["AltUnits"] != null)
                 {
                     AltUnits = (AltUnits)Enum.Parse(typeof(AltUnits), node.Attributes["AltUnits"].Value);
-                }
-                else
-                {
-                    AltUnits = AltUnits.Meters;
                 }
             }
 

--- a/WWTExplorer3d/ReferenceFrame.cs
+++ b/WWTExplorer3d/ReferenceFrame.cs
@@ -368,7 +368,9 @@ namespace TerraViewer
             {
                 xmlWriter.WriteAttributeString("Lat", Lat.ToString());
                 xmlWriter.WriteAttributeString("Lng", Lng.ToString());
-                xmlWriter.WriteAttributeString("Altitude", Altitude.ToString());
+                double scaleFactor = UiTools.GetScaleFactor(AltUnits, 1);
+                double altInMeters = scaleFactor * Altitude;
+                xmlWriter.WriteAttributeString("Altitude", altInMeters.ToString());
                 xmlWriter.WriteAttributeString("AltUnits", AltUnits.ToString());
             }
             xmlWriter.WriteAttributeString("RotationalPeriod", RotationalPeriod.ToString());
@@ -429,11 +431,13 @@ namespace TerraViewer
             {
                 Lat = Double.Parse(node.Attributes["Lat"].Value);
                 Lng = Double.Parse(node.Attributes["Lng"].Value);
-                Altitude = Double.Parse(node.Attributes["Altitude"].Value);
+                double altInMeters = Double.Parse(node.Attributes["Altitude"].Value);
                 if (node.Attributes["AltUnits"] != null)
                 {
                     AltUnits = (AltUnits)Enum.Parse(typeof(AltUnits), node.Attributes["AltUnits"].Value);
                 }
+                double scaleFactor = UiTools.GetScaleFactor(AltUnits, 1);
+                Altitude = altInMeters / scaleFactor;
             }
 
             RotationalPeriod = Double.Parse(node.Attributes["RotationalPeriod"].Value);


### PR DESCRIPTION
This PR adds support for specific the position of a fixed spherical reference frame in different units.

The code changes for this are, I think, relatively straightforward. Since this option doesn't apply to synodic reference frames, I've hidden the label and dropdown that I added for handling the units in the reference frame wizard when the frame in question is synodic.