### PR TITLE
VOTable layer properties and colormaps

### DIFF
--- a/WWTExplorer3d/LayerManager.cs
+++ b/WWTExplorer3d/LayerManager.cs
@@ -1875,6 +1875,14 @@ namespace TerraViewer
                 target.CleanUp();
                 LoadTree();
             }
+            else if (layerTree.SelectedNode.Tag is VoTableLayer)
+            {
+                VoTableLayer target = (VoTableLayer)layerTree.SelectedNode.Tag;
+                DataWizard.ShowPropertiesSheet(target);
+
+                target.CleanUp();
+                LoadTree();
+            }
             else if (layerTree.SelectedNode.Tag is SpreadSheetLayer || layerTree.SelectedNode.Tag is Object3dLayer)
             {
                 Object3dProperties props = new Object3dProperties();

--- a/WWTExplorer3d/SpreadSheetLayer.cs
+++ b/WWTExplorer3d/SpreadSheetLayer.cs
@@ -1375,7 +1375,7 @@ namespace TerraViewer
                             case ColorMaps.Per_Column_Literal:
                                 if (ColorMapColumn > -1)
                                 {
-                                    lastItem.Color = ParseColor(row[ColorMapColumn], color);
+                                    lastItem.Color = UiTools.ParseColor(row[ColorMapColumn], color);
                                 }
                                 else
                                 {
@@ -1875,54 +1875,6 @@ namespace TerraViewer
             }
         }
       
-
-        private Color ParseColor(string colorText, Color defaultColor)
-        {
-            try
-            {
-                int val = 0;
-
-                bool match = int.TryParse(colorText, System.Globalization.NumberStyles.HexNumber, NumberFormatInfo.InvariantInfo, out val);
-
-
-                if (match)
-                {
-                    return Color.FromArgb(val);
-                }
-            }
-            catch
-            {
-            }
-            try
-            {
-                float opacity = 1.0f;
-                int pos = colorText.IndexOf("%");
-                if (pos > -1)
-                {
-                    float opa = 0;
-                    if (float.TryParse(colorText.Substring(0, pos), out opa))
-                    {
-                        opacity = opa/100f;
-                    }
-
-                    colorText = colorText.Substring(pos+1);
-                }
-
-                Color foundColor = Color.FromName(colorText.Replace(" ",""));
-
-                foundColor = Color.FromArgb((int)Math.Min(255, Math.Max(0, opacity * 255)), foundColor);
-
-                return foundColor;
-            }
-            catch
-            {
-
-            }
-
-
-
-            return defaultColor;
-        }
 
         public static DateTime ParseDate(string date)
         {

--- a/WWTExplorer3d/UiTools.cs
+++ b/WWTExplorer3d/UiTools.cs
@@ -840,6 +840,52 @@ namespace TerraViewer
  
         }
 
+        public static Color ParseColor(string colorText, Color defaultColor)
+        {
+            try
+            {
+                int val = 0;
+
+                bool match = int.TryParse(colorText, System.Globalization.NumberStyles.HexNumber, System.Globalization.NumberFormatInfo.InvariantInfo, out val);
+
+
+                if (match)
+                {
+                    return Color.FromArgb(val);
+                }
+            }
+            catch
+            {
+            }
+            try
+            {
+                float opacity = 1.0f;
+                int pos = colorText.IndexOf("%");
+                if (pos > -1)
+                {
+                    float opa = 0;
+                    if (float.TryParse(colorText.Substring(0, pos), out opa))
+                    {
+                        opacity = opa / 100f;
+                    }
+
+                    colorText = colorText.Substring(pos + 1);
+                }
+
+                Color foundColor = Color.FromName(colorText.Replace(" ", ""));
+
+                foundColor = Color.FromArgb((int)Math.Min(255, Math.Max(0, opacity * 255)), foundColor);
+
+                return foundColor;
+            }
+            catch
+            {
+
+            }
+
+            return defaultColor;
+        }
+
         public static string FormatDistancePlain(double distance)
         {
             if (distance < .0001)

--- a/WWTExplorer3d/VoTableLayer.cs
+++ b/WWTExplorer3d/VoTableLayer.cs
@@ -307,7 +307,37 @@ namespace TerraViewer
                             }
 
 
-                            lastItem.Color = color;
+                            switch (ColorMap)
+                            {
+                                case ColorMaps.Same_For_All:
+                                    lastItem.Color = color;
+                                    break;
+                                case ColorMaps.Per_Column_Literal:
+                                    if (ColorMapColumn > -1)
+                                    {
+                                        lastItem.Color = UiTools.ParseColor(row[ColorMapColumn].ToString(), color);
+                                    }
+                                    else
+                                    {
+                                        lastItem.Color = color;
+                                    }
+                                    break;
+                                //case ColorMaps.Group_by_Range:
+                                //    break;
+                                //case ColorMaps.Gradients_by_Range:
+                                //    break;       
+                                case ColorMaps.Group_by_Values:
+                                    if (!ColorDomainValues.ContainsKey(row[ColorMapColumn].ToString()))
+                                    {
+                                        MakeColorDomainValues();
+                                    }
+                                    lastItem.Color = Color.FromArgb(ColorDomainValues[row[ColorMapColumn].ToString()].MarkerIndex);
+                                    break;
+
+                                default:
+                                    break;
+                            }
+
                             if (sizeColumn > -1)
                             {
 
@@ -400,6 +430,23 @@ namespace TerraViewer
                 shapeFileVertex = new TimeSeriesPointSpriteSet(RenderContext11.PrepDevice, vertList.ToArray());
             }
             return true;
+        }
+
+        public override string[] GetDomainValues(int column)
+        {
+            List<string> domainValues = new List<String>();
+            if (column > -1)
+            {
+                foreach (VoRow row in table.Rows)
+                {
+                    if (!domainValues.Contains(row[column].ToString()))
+                    {
+                        domainValues.Add(row[column].ToString());
+                    }
+                }
+            }
+            domainValues.Sort();
+            return domainValues.ToArray();
         }
 
         private void AddSiapStcRow(string stcsColName, VoRow row, bool selected)


### PR DESCRIPTION
This PR adds colormap support for VOTable layers, as well as allows VOTable layer properties to be manipulated by the same UI as used for spreadsheet layers.

Adding colormap support was straightforward; the relevant code was largely stolen from `SpreadSheetLayer`. The implementation of `GetDomainValues` in `VoTableLayer` is simpler since VO tables don't support filtering.

The code that creates the properties window expects a `TimeSeriesLayer`, the parent of both `SpreadSheetLayer` and `VoTableLayer`, so allowing this to be used for VO tables was basically trivial.

This should resolve #184, and exposes the 'Show Far Side Markers' setting for VOTables, which I suspect will solve #183 (from my testing with the exoplanet VOTable layer, this makes a noticeable difference in the area centered around our solar system when zoomed out to a galactic scale).