### PR TITLE
Use new login6 API endpoint

### DIFF
--- a/WWTExplorer3d/3dWIndow.cs
+++ b/WWTExplorer3d/3dWIndow.cs
@@ -7758,7 +7758,7 @@ namespace TerraViewer
                 WebClient Client = new WebClient();
 
                 string yourVersion = System.Reflection.Assembly.GetExecutingAssembly().GetName().Version.ToString();
-                string url = String.Format("http://www.worldwidetelescope.org/wwtweb/login.aspx?user={0}&Version={1}&Equinox=true", Properties.Settings.Default.UserRatingGUID.ToString("D"), yourVersion);
+                string url = String.Format("http://www.worldwidetelescope.org/wwtweb/login6.aspx?user={0}&Version={1}", Properties.Settings.Default.UserRatingGUID.ToString("D"), yourVersion);
                 string data = Client.DownloadString(url);
 
                 string[] lines = data.Split(new char[] { '\n' });


### PR DESCRIPTION
This PR is a companion to https://github.com/WorldWideTelescope/wwt-website/pull/288. When checking for updates, the login URL is changed to use the new `login6` endpoint, and the `Equinox` parameter is removed.