### PR TITLE
Fix issue with layer colors and tours

### DIFF
--- a/WWTExplorer3d/Layer.cs
+++ b/WWTExplorer3d/Layer.cs
@@ -178,10 +178,10 @@ namespace TerraViewer
         public virtual double[] GetParams()
         {
             double[] paramList = new double[5];
-            paramList[0] = color.R/255;
-            paramList[1] = color.G/255;
-            paramList[2] = color.B/255;
-            paramList[3] = color.A/255;
+            paramList[0] = ((double)color.R) / 255;
+            paramList[1] = ((double)color.G) / 255;
+            paramList[2] = ((double)color.B) / 255;
+            paramList[3] = ((double)color.A) / 255;
             paramList[4] = opacity;
 
 

--- a/WWTExplorer3d/LayerManager.cs
+++ b/WWTExplorer3d/LayerManager.cs
@@ -1945,7 +1945,15 @@ namespace TerraViewer
                     TourDocument tour = tourEdit.Tour;
                     if (tour != null && tour.CurrentTourStop != null)
                     {
-                        tour.CurrentTourStop.Layers[layer.ID].FrameParams = layer.GetParams();
+                        Dictionary<Guid, LayerInfo> layers = tour.CurrentTourStop.Layers;
+                        if (layers.ContainsKey(layer.ID))
+                        {
+                            LayerInfo info = tour.CurrentTourStop.Layers[layer.ID];
+                            double[] pars = layer.GetParams();
+                            info.FrameParams = pars;
+                            info.StartParams = pars;
+                            info.EndParams = pars;
+                        }
                     }
                 }
             }

--- a/WWTExplorer3d/LayerManager.cs
+++ b/WWTExplorer3d/LayerManager.cs
@@ -1937,6 +1937,17 @@ namespace TerraViewer
             if (picker.ShowDialog() == DialogResult.OK)
             {
                 layer.Color = picker.Color;
+
+                // We're currently editing a tour stop, update the FrameParams for this layer
+                TourEditTab tourEdit = Earth3d.MainWindow.TourEdit;
+                if (tourEdit != null)
+                {
+                    TourDocument tour = tourEdit.Tour;
+                    if (tour != null && tour.CurrentTourStop != null)
+                    {
+                        tour.CurrentTourStop.Layers[layer.ID].FrameParams = layer.GetParams();
+                    }
+                }
             }
         }
 

--- a/WWTExplorer3d/TourStop.cs
+++ b/WWTExplorer3d/TourStop.cs
@@ -2241,7 +2241,15 @@ namespace TerraViewer
             foreach (XmlNode layer in layersNode)
             {
                 LayerInfo info = new LayerInfo();
-                info.ID = new Guid(layer.InnerText);
+
+                if (layer.Attributes["Id"] != null)
+                {
+                    info.ID = new Guid(layer.Attributes["Id"].Value);
+                }
+                else
+                {
+                    info.ID = new Guid(layer.InnerText);
+                }
                 info.StartOpacity = Convert.ToSingle(layer.Attributes["StartOpacity"].Value);
                 info.EndOpacity = Convert.ToSingle(layer.Attributes["EndOpacity"].Value);
 

--- a/WWTExplorer3d/TourStop.cs
+++ b/WWTExplorer3d/TourStop.cs
@@ -2241,15 +2241,7 @@ namespace TerraViewer
             foreach (XmlNode layer in layersNode)
             {
                 LayerInfo info = new LayerInfo();
-
-                if (layer.Attributes["Id"] != null)
-                {
-                    info.ID = new Guid(layer.Attributes["Id"].Value);
-                }
-                else
-                {
-                    info.ID = new Guid(layer.InnerText);
-                }
+                info.ID = new Guid(layer.InnerText);
                 info.StartOpacity = Convert.ToSingle(layer.Attributes["StartOpacity"].Value);
                 info.EndOpacity = Convert.ToSingle(layer.Attributes["EndOpacity"].Value);
 


### PR DESCRIPTION
This PR aims to fix an issue where changes to the layer color in a tour are not persistent within the tour - whenever a user does something else in the tour editor (e.g., moves to another slide), the layer color reverts back to what it was originally.

The source of this problem is the tour's `LayerInfo` object for the layer in question not being updated to match the layer itself. To fix this, this PR adds additional functionality to the callback triggered when the color is changed via the color picker in the layer manager. The new piece of code checks whether there is a current tour, and if so, whether the given layer is visible on the current tour stop. If it is, the `FrameParams`, `StartParams`, and `EndParams` for the current tour stop are updated to match the color. I don't see anywhere else in the UI that a user can change a layer color (and I didn't want to put this code in the setter for the layer's `Color` attribute).

Additionally, this PR fixed an integer vs. floating-point division issue that occurs when getting `LayerInfo` params for a layer, which currently causes every RGBA value obtained in this way to be either 0 or 255.

@pkgw It turns out the layer ID issue that we had talked about isn't an issue at all - not because of any Guid black magic, but because of the assignment [here](https://github.com/WorldWideTelescope/wwt-windows-client/blob/master/WWTExplorer3d/LayerManagerCore.cs#L1635).