### PR TITLE
Workaround for jagged lines on HiDPI displays

### DIFF
--- a/WWTExplorer3d/3dWindow.cs
+++ b/WWTExplorer3d/3dWindow.cs
@@ -1180,6 +1180,11 @@ namespace TerraViewer
                 {
                 }
             }
+
+            // On HiDPI displays, jagged lines can appear when the client starts up,
+            // but disappear on a window resize.
+            // So, to avoid this, we explicitly call OnResize here
+            OnResize(EventArgs.Empty);
         }
 
         public static void BackgroundInit()


### PR DESCRIPTION
On HiDPI displays, jagged lines can appear when the client opens, but disappear on a window resize - see #192. This PR provides a workaround for that issue by explicitly calling `OnResize` at the end of the constructor for the main window.