### PR TITLE
Mark layers as dirty when their reference frame's mean radius changes

### DIFF
--- a/WWTExplorer3d/FrameWizardMain.cs
+++ b/WWTExplorer3d/FrameWizardMain.cs
@@ -41,6 +41,7 @@ namespace TerraViewer
         {
             bool failed = false;
 
+            double initialMeanRadius = frame.MeanRadius;
             frame.MeanRadius = ParseAndValidateDouble(MeanRadius, frame.MeanRadius, ref failed);
             frame.Oblateness = ParseAndValidateDouble(Oblateness, frame.Oblateness, ref failed);
             frame.Scale = ParseAndValidateDouble(Scale, frame.Scale, ref failed);
@@ -52,6 +53,18 @@ namespace TerraViewer
          
             frame.ShowAsPoint = ShowAsPoint.Checked;
             frame.ShowOrbitPath = ShowOrbitPath.Checked;
+
+            // If the mean radius changes, mark each of the frame's layers as dirty so that it is re-drawn
+            bool radiusChanged = initialMeanRadius != frame.MeanRadius;
+            if (radiusChanged && LayerManager.AllMaps.ContainsKey(frame.name))
+            {
+                LayerMap map = LayerManager.AllMaps[frame.name];
+                foreach (Layer layer in map.Layers)
+                {
+                    layer.CleanUp();
+                }
+            }
+
             return !failed;
         }
 


### PR DESCRIPTION
Currently, when a reference frame's mean radius is updated, its layers are not redrawn. This seems to be one of the causes of the problem in #198. While the distance of the points from the center is modified appropriately, the positions of points in some layers depend on the frame's mean radius in a non-linear fashion. These layers will thus display incorrectly until another action (such as closing the layer properties window) marks the layer as "dirty". This PR fixes this issue by marking each of a reference frame's layers as dirty when the frame's mean radius is updated in the UI.

I think there are two points worth mentioning here:
* As far as I can tell, the mean radius is the only property that affects layer display in this way, so the added piece of code only checks the layer's mean radius to avoid any unnecessary re-draws.
* I debated walking through the tree of child reference frames and flagging their layers as well, but I couldn't find any dependence on parent reference frames inside of layers, so I don't think this is necessary.