### PR TITLE
Fix display of OBJ models in Right Handed mode

### DIFF
--- a/WWTExplorer3d/Object3d.cs
+++ b/WWTExplorer3d/Object3d.cs
@@ -2566,8 +2566,8 @@ namespace TerraViewer
                                         if (FlipHandedness)
                                         {
                                             indexiesA = GetIndexies(parts[1]);
-                                            indexiesC = GetIndexies(parts[partIndex]);          
-                                            indexiesB = GetIndexies(parts[partIndex - 1]);
+                                            indexiesB = GetIndexies(parts[partIndex]);
+                                            indexiesC = GetIndexies(parts[partIndex - 1]);
                                         }
                                         else
                                         {

--- a/WWTExplorer3d/Object3d.cs
+++ b/WWTExplorer3d/Object3d.cs
@@ -862,6 +862,7 @@ namespace TerraViewer
             if (path.ToLower().EndsWith(".obj"))
             {
                 ObjType = true;
+                flipHandedness = true;
             }
 
             if (lightID == 0)


### PR DESCRIPTION
Currently, there is a bug when displaying a 3d model from an OBJ file in Right Handed mode that causes the faces to display incorrectly. For an example, see the screenshots in #169. I tried this out with a few other OBJ models and got similar results.

This issue is [here](https://github.com/WorldWideTelescope/wwt-windows-client/blob/e521d6314820ad6b0bb4e03238b111e1d9b0384a/WWTExplorer3d/Object3d.cs#L2566), where both parts of the if-else block do the same thing. The fix in this PR is to exchange `indexiesB` and `indexiesC` in the `FlipHandedness` block. The reason for this is that the three vertices added at a time here define a triangle. These groups of three vertices are then used [here](https://github.com/WorldWideTelescope/wwt-windows-client/blob/e521d6314820ad6b0bb4e03238b111e1d9b0384a/WWTExplorer3d/Object3d.cs#L1799) to calculate the normal to the triangle via a cross product. Exchanging the two index lists changes the signs of these cross products, which needs to be done when the orientation changes.

In case anyone finds the indices confusing, (`1`, `partIndex-1`, and `partIndex`), the vertices in an OBJ file are listed in counter-clockwise order. So, if I have vertices indexed as 1, 2, 3, ..., then if X < Y, then the triangles with vertices 1 X Y should all have an outward normal consistent with the face as a whole. Thus, the triangle with vertices 1 Y X will have the opposite orientation, which we want when switching handedness. Basically, I think this part of the algorithm is doing a [fan triangulation](https://en.wikipedia.org/wiki/Fan_triangulation) of the face.

