### PR TITLE
Loading of HiPS layers

### DIFF
--- a/WWTExplorer3d/3dWindow.cs
+++ b/WWTExplorer3d/3dWindow.cs
@@ -13519,22 +13519,9 @@ namespace TerraViewer
             if (input.ShowDialog() == DialogResult.OK)
             {
                 string url = input.ResultText;
-                string baseUrl = "";
-
-                if (url.Contains("/Norder"))
-                {
-                    baseUrl = url.Substring(0, url.IndexOf("/Norder"));
-                }
-                else
-                {
-                    baseUrl = url;
-                }
-                if (!baseUrl.EndsWith("/"))
-                {
-                    baseUrl = baseUrl + "/";
-                }
-
-                url = baseUrl + "Norder{0}/Dir{1}/Npix{2}";
+                Tuple<String,String> urls = HipsProperties.GetUrlAndBase(url);
+                url = urls.Item1;
+                string baseUrl = urls.Item2;
 
                 HipsProperties hipsProperties = HipsProperties.GetProperties(url);
 
@@ -13542,44 +13529,11 @@ namespace TerraViewer
                 {
                     var props = hipsProperties.Properties;
 
-                    ImageSetHelper ish = ImageSetHelperFromHipsProperties(url, baseUrl, props);
+                    ImageSetHelper ish = ImageSetHelper.FromHipsProperties(url, baseUrl, props);
                     ish.TableMetadata = hipsProperties.VoTable;
                     LayerManager.AddImagesetLayer(ish, "Sky");
                 }
             }
-        }
-
-        private static ImageSetHelper ImageSetHelperFromHipsProperties(string url, string baseUrl, Dictionary<string, string> props)
-        {
-            ImageSetHelper ish = new ImageSetHelper(
-                props["obs_title"],
-                url,
-                ImageSetType.Sky,
-                GetBandPassFromString(props.ContainsKey("obs_regime") ? props["obs_regime"] : ""),
-                ProjectionType.Healpix,
-                Math.Abs(url.GetHashCode32()),
-                0,
-                int.Parse(props["hips_order"]),
-                props.ContainsKey("hips_tile_width") ? int.Parse(props["hips_tile_width"]) : 512,
-                180,
-                props["hips_tile_format"],
-                false,
-                "0123",
-                0, 0, 0, false,
-                baseUrl + "preview.jpg",
-                false,
-                false,
-                1,
-                0,
-                0,
-                props.ContainsKey("obs_copyright") ? props["obs_copyright"] : "",
-                props.ContainsKey("obs_copyright_url") ? props["obs_copyright_url"] : "",
-                "",
-                "",
-                1,
-                "Sky");
-            ish.Properties = props;
-            return ish;
         }
 
         private void GetMasterHipsListAsWtml()
@@ -13659,25 +13613,9 @@ namespace TerraViewer
                     isHeatmap = true;
                 }
 
-                string url = prop.Properties["hips_service_url"];
-                string baseUrl = "";
+                (string url, string baseUrl) = HipsProperties.GetUrlAndBase(prop.Properties["hips_service_url"]);
 
-                if (url.Contains("/Norder"))
-                {
-                    baseUrl = url.Substring(0, url.IndexOf("/Norder"));
-                }
-                else
-                {
-                    baseUrl = url;
-                }
-                if (!baseUrl.EndsWith("/"))
-                {
-                    baseUrl = baseUrl + "/";
-                }
-
-                url = baseUrl + "Norder{0}/Dir{1}/Npix{2}";
-
-                ImageSetHelper ish = ImageSetHelperFromHipsProperties(url, baseUrl, prop.Properties);
+                ImageSetHelper ish = ImageSetHelper.FromHipsProperties(url, baseUrl, prop.Properties);
 
                 if (ish.Extension == "tsv")
                 {
@@ -13707,33 +13645,6 @@ namespace TerraViewer
             folder.SaveToFile(@"c:\temp\allhips.wtml");
 
         }
-
-        private static BandPass GetBandPassFromString(string bandPass)
-        {
-            switch (bandPass)
-            {
-                case "Gamma-ray":
-                    return BandPass.Gamma;
-                case "IR":
-                case "Infrared,Infrared":
-                case "Infrared":
-                case "Infrared/AKARI-FIS": 
-                    return BandPass.IR;
-                case "Mlillimeter":
-                case "Radio":
-                    return BandPass.Radio;
-                case "UV":
-                    return BandPass.Ultraviolet;
-                case "X-ray":
-                    return BandPass.XRay;
-                case "Optical":
-                case "Optical,Infrared":
-                    return BandPass.Visible;
-                default:
-                    return BandPass.Visible;
-            }          
-        }
-    }
 
     [SecurityPermission(SecurityAction.LinkDemand, Flags = SecurityPermissionFlag.UnmanagedCode)]
     public class DataMessageFilter : IMessageFilter

--- a/WWTExplorer3d/3dWindow.cs
+++ b/WWTExplorer3d/3dWindow.cs
@@ -13519,7 +13519,7 @@ namespace TerraViewer
             if (input.ShowDialog() == DialogResult.OK)
             {
                 string url = input.ResultText;
-                Tuple<String,String> urls = HipsProperties.GetUrlAndBase(url);
+                Tuple<string,string> urls = HipsProperties.GetUrlAndBase(url);
                 url = urls.Item1;
                 string baseUrl = urls.Item2;
 
@@ -13613,7 +13613,9 @@ namespace TerraViewer
                     isHeatmap = true;
                 }
 
-                (string url, string baseUrl) = HipsProperties.GetUrlAndBase(prop.Properties["hips_service_url"]);
+                Tuple<string,string> urls = HipsProperties.GetUrlAndBase(prop.Properties["hips_service_url"]);
+                string url = urls.Item1;
+                string baseUrl = urls.Item2;
 
                 ImageSetHelper ish = ImageSetHelper.FromHipsProperties(url, baseUrl, prop.Properties);
 
@@ -13645,6 +13647,7 @@ namespace TerraViewer
             folder.SaveToFile(@"c:\temp\allhips.wtml");
 
         }
+    }
 
     [SecurityPermission(SecurityAction.LinkDemand, Flags = SecurityPermissionFlag.UnmanagedCode)]
     public class DataMessageFilter : IMessageFilter

--- a/WWTExplorer3d/GuidUtils.cs
+++ b/WWTExplorer3d/GuidUtils.cs
@@ -4,12 +4,18 @@ using System.Security.Cryptography;
 
 namespace TerraViewer
 {
-    // This code is adapted from https://github.com/Faithlife/FaithlifeUtility/blob/master/src/Faithlife.Utility/GuidUtility.cs
+    
     class GuidUtils
     {
 
+        // The value 1420736a-a637-40a7-813a-ba692e72204e is a UUID (generated using the uuid CLI)
+        // that serves as a 'namespace' for our GUIDs.
+        // The WWT WebGL engine uses the same namespace, so this application and the WebGL engine
+        // will generate the same UUID from the same input string
         private static Guid wwtNamespace = new Guid("1420736a-a637-40a7-813a-ba692e72204e");
 
+        // This code is adapted from https://github.com/Faithlife/FaithlifeUtility/blob/master/src/Faithlife.Utility/GuidUtility.cs
+        // which is licensed under the MIT License
         public static Guid Create(string name, int version)
         {
             if (name == null)

--- a/WWTExplorer3d/GuidUtils.cs
+++ b/WWTExplorer3d/GuidUtils.cs
@@ -1,0 +1,78 @@
+﻿using System;
+using System.Text;
+using System.Security.Cryptography;
+
+namespace TerraViewer
+{
+    // This code is adapted from https://github.com/Faithlife/FaithlifeUtility/blob/master/src/Faithlife.Utility/GuidUtility.cs
+    class GuidUtils
+    {
+
+        private static Guid wwtNamespace = new Guid("1420736a-a637-40a7-813a-ba692e72204e");
+
+        public static Guid Create(string name, int version)
+        {
+            if (name == null)
+                throw new ArgumentNullException("name");
+            if (version != 3 && version != 5)
+                throw new ArgumentOutOfRangeException("version", "version must be either 3 or 5.");
+
+            // convert the name to a sequence of octets (as defined by the standard or conventions of its namespace) (step 3)
+            // ASSUME: UTF-8 encoding is always appropriate
+            byte[] nameBytes = Encoding.UTF8.GetBytes(name);
+
+            // convert the namespace UUID to network order (step 3)
+            byte[] namespaceBytes = wwtNamespace.ToByteArray();
+            SwapByteOrder(namespaceBytes);
+
+            // comput the hash of the name space ID concatenated with the name (step 4)
+            byte[] hash;
+            using (HashAlgorithm algorithm = version == 3 ? (HashAlgorithm)MD5.Create() : SHA1.Create())
+            {
+                algorithm.TransformBlock(namespaceBytes, 0, namespaceBytes.Length, null, 0);
+                algorithm.TransformFinalBlock(nameBytes, 0, nameBytes.Length);
+                hash = algorithm.Hash;
+            }
+
+            // most bytes from the hash are copied straight to the bytes of the new GUID (steps 5-7, 9, 11-12)
+            byte[] newGuid = new byte[16];
+            Array.Copy(hash, 0, newGuid, 0, 16);
+
+            // set the four most significant bits (bits 12 through 15) of the time_hi_and_version field to the appropriate 4-bit version number from Section 4.1.3 (step 8)
+            newGuid[6] = (byte)((newGuid[6] & 0x0F) | (version << 4));
+
+            // set the two most significant bits (bits 6 and 7) of the clock_seq_hi_and_reserved to zero and one, respectively (step 10)
+            newGuid[8] = (byte)((newGuid[8] & 0x3F) | 0x80);
+
+            // convert the resulting UUID to local byte order (step 13)
+            SwapByteOrder(newGuid);
+            return new Guid(newGuid);
+        }
+
+        // Converts a GUID (expressed as a byte array) to/from network order (MSB-first).
+        internal static void SwapByteOrder(byte[] guid)
+        {
+            SwapBytes(guid, 0, 3);
+            SwapBytes(guid, 1, 2);
+            SwapBytes(guid, 4, 5);
+            SwapBytes(guid, 6, 7);
+        }
+
+        private static void SwapBytes(byte[] guid, int left, int right)
+        {
+            byte temp = guid[left];
+            guid[left] = guid[right];
+            guid[right] = temp;
+        }
+
+        public static Guid CreateV3(string name)
+        {
+            return GuidUtils.Create(name, 3);
+        }
+
+        public static Guid CreateV5(string name)
+        {
+            return GuidUtils.Create(name, 5);
+        }
+    }
+}

--- a/WWTExplorer3d/Healpix/HealpixTile.cs
+++ b/WWTExplorer3d/Healpix/HealpixTile.cs
@@ -1772,6 +1772,27 @@ namespace TerraViewer
             return props;
         }
 
+        public static Tuple<String,String> GetUrlAndBase(string url)
+        {
+            string baseUrl = "";
+            if (url.Contains("/Norder"))
+            {
+                baseUrl = url.Substring(0, url.IndexOf("/Norder"));
+            }
+            else
+            {
+                baseUrl = url;
+            }
+            if (!baseUrl.EndsWith("/"))
+            {
+                baseUrl = baseUrl + "/";
+            }
+
+            url = baseUrl + "Norder{0}/Dir{1}/Npix{2}";
+
+            return Tuple.Create(url, baseUrl);
+        }
+
         public static HipsProperties GetProperties(string url)
         {
             HipsProperties props = new HipsProperties();

--- a/WWTExplorer3d/ImageSet.cs
+++ b/WWTExplorer3d/ImageSet.cs
@@ -418,7 +418,7 @@ namespace TerraViewer
 #if !WINDOWS_UWP
                     if (projection == ProjectionType.Healpix && fileType == ".tsv")
                     {
-                        Tuple<String,String> urls = HipsProperties.GetUrlAndBase(url);
+                        Tuple<string,string> urls = HipsProperties.GetUrlAndBase(url);
                         url = urls.Item1;
                         string baseUrl = urls.Item2;
 

--- a/WWTExplorer3d/ImageSet.cs
+++ b/WWTExplorer3d/ImageSet.cs
@@ -327,6 +327,9 @@ namespace TerraViewer
                         case "skyimage":
                             projection = ProjectionType.SkyImage;
                             break;
+                        case "healpix":
+                            projection = ProjectionType.Healpix;
+                            break;
                     }
 
                     string fileType = node.Attributes["FileType"].Value.ToString();

--- a/WWTExplorer3d/ImageSet.cs
+++ b/WWTExplorer3d/ImageSet.cs
@@ -415,6 +415,7 @@ namespace TerraViewer
                     }
 
                     string url = node.Attributes["Url"].Value.ToString();
+#if !WINDOWS_UWP
                     if (projection == ProjectionType.Healpix && fileType == ".tsv")
                     {
                         Tuple<String,String> urls = HipsProperties.GetUrlAndBase(url);
@@ -429,6 +430,7 @@ namespace TerraViewer
                             return ish;
                         }
                     }
+#endif
 
                     return new ImageSetHelper(node.Attributes["Name"].Value.ToString(), url, type, bandPass, projection, Math.Abs(node.Attributes["Url"].Value.GetHashCode32()), Convert.ToInt32(node.Attributes["BaseTileLevel"].Value), Convert.ToInt32(node.Attributes["TileLevels"].Value), 256, Convert.ToDouble(node.Attributes["BaseDegreesPerTile"].Value), fileType, Convert.ToBoolean(node.Attributes["BottomsUp"].Value.ToString()), node.Attributes["QuadTreeMap"].Value.ToString(), Convert.ToDouble(node.Attributes["CenterX"].Value), Convert.ToDouble(node.Attributes["CenterY"].Value), Convert.ToDouble(node.Attributes["Rotation"].Value), Convert.ToBoolean(node.Attributes["Sparse"].Value.ToString()), thumbnailUrl, stockSet, elevationModel, wf, offsetX, offsetY, creditText, creditsUrl, demUrl, alturl, meanRadius, referenceFrame);
                 }

--- a/WWTExplorer3d/ImageSetLayer.cs
+++ b/WWTExplorer3d/ImageSetLayer.cs
@@ -48,6 +48,10 @@ namespace TerraViewer
             imageSet = set;
 #if !WINDOWS_UWP
             GetDefaultColumns();
+            if (set.Projection == ProjectionType.Healpix && set.Extension == "tsv")
+            {
+                this.ID = GuidUtils.CreateV5(set.Name);
+            }
 #endif
         }
 

--- a/WWTExplorer3d/WWTExplorer.csproj
+++ b/WWTExplorer3d/WWTExplorer.csproj
@@ -243,6 +243,7 @@
       <DependentUpon>GridCreator.cs</DependentUpon>
     </Compile>
     <Compile Include="Catalogs.cs" />
+    <Compile Include="GuidUtils.cs" />
     <Compile Include="CoverageMap.cs" />
     <Compile Include="ExportSTL.cs">
       <SubType>Form</SubType>
@@ -2551,8 +2552,10 @@
   <Import Project="..\packages\SharpDX.Toolkit.2.6.3\build\SharpDX.Toolkit.targets" Condition="Exists('..\packages\SharpDX.Toolkit.2.6.3\build\SharpDX.Toolkit.targets')" />
   <ProjectExtensions>
     <Cranko>
-      <CrankoInternalDepVersion>{737a81a8-553c-49a9-8f17-5adf691a56b2}=manual:unused</CrankoInternalDepVersion> <!-- OculusWrap -->
-      <CrankoInternalDepVersion>{6c205caa-423d-48b8-813b-e586e105c71b}=manual:unused</CrankoInternalDepVersion> <!-- WWTCore -->
+      <CrankoInternalDepVersion>{737a81a8-553c-49a9-8f17-5adf691a56b2}=manual:unused</CrankoInternalDepVersion>
+      <!-- OculusWrap -->
+      <CrankoInternalDepVersion>{6c205caa-423d-48b8-813b-e586e105c71b}=manual:unused</CrankoInternalDepVersion>
+      <!-- WWTCore -->
     </Cranko>
   </ProjectExtensions>
 </Project>


### PR DESCRIPTION
This PR is, in some sense, the companion to https://github.com/WorldWideTelescope/wwt-webgl-engine/pull/178. It attempts to solve two main problems:

* Currently, image sets with the Healpix projection aren't loaded correctly from XML due to a missing case in the switch statement [here](https://github.com/WorldWideTelescope/wwt-windows-client/blob/master/WWTExplorer3d/ImageSet.cs#L306). This PR fixes this by adding the appropriate case check.
* In order to correctly load HiPS layers (defined as Healpix projection + file extension `.tsv`), this PR modifies the client to create the image set from the HiPS url, as is done when adding a HiPS survey via Explore > Open > HIPS Progressive Survey. I did a bit of code refactoring to help with this.

From what I can tell, the UWP version of the client doesn't have support for Healpix tiles. To get around this, in `ImageSetHelper::FromXmlNode`, I wrapped the logic for creating an `ImageSetHelper` using HiPS properties in preprocessor directives so that it's omitted in UWP.