### PR TITLE
Fix issue with time offset at non-unit clock rates and update speed text with shortcuts

### DIFF
--- a/WWTCore/WWTCore/SpaceTimeController.cs
+++ b/WWTCore/WWTCore/SpaceTimeController.cs
@@ -18,7 +18,7 @@ namespace TerraViewer
                 if (timeRate != 1.0)
                 {
                     TimeSpan ts = justNow - last;
-                    long ticks = (long)(ts.Ticks * timeRate);
+                    long ticks = (long)(ts.Ticks * (timeRate - 1));
                     offset = offset.Add(new TimeSpan(ticks));
                 }
                 last = justNow;

--- a/WWTExplorer3d/3dWindow.cs
+++ b/WWTExplorer3d/3dWindow.cs
@@ -6942,9 +6942,17 @@ namespace TerraViewer
                         break;
                     case Keys.F:
                         SpaceTimeController.Faster();
+                        if (viewPane != null)
+                        {
+                            viewPane.UpdateSpeed();
+                        }
                         break;
                     case Keys.S:
                         SpaceTimeController.Slower();
+                        if (viewPane != null)
+                        {
+                            viewPane.UpdateSpeed();
+                        }
                         break;
                     case Keys.H:
                         // turn friction on and off

--- a/WWTExplorer3d/View.cs
+++ b/WWTExplorer3d/View.cs
@@ -227,14 +227,14 @@ namespace TerraViewer
             UpdateSpeed();
         }
 
-        private void UpdateSpeed()
+        public void UpdateSpeed()
         {
 
             if (SpaceTimeController.TimeRate == 1.0)
             {
                 TimeMode.Text = Language.GetLocalizedText(513, "Real Time");
             }
-            else if (SpaceTimeController.TimeRate == -2.0)
+            else if (SpaceTimeController.TimeRate == -1.0)
             {
                 TimeMode.Text = Language.GetLocalizedText(521, "Reverse Time");
             }


### PR DESCRIPTION
This is the companion to https://github.com/WorldWideTelescope/wwt-webgl-engine/pull/302. See that PR and https://github.com/WorldWideTelescope/wwt-webgl-engine/issues/301 for a discussion of the issue with time rates. The `SpaceTimeController` in the Windows client has the same logic, and thus the fix is the same.

The Windows client seemed to already be aware of this issue in some sense, as the condition for displaying the "Reverse Time" text checked that the rate was -2 rather than the expected -1.

In the course of checking that the Windows client also had this issue (and testing my fix), I realized that the speed text doesn't currently update when time is changed using the F/S shortcut keys - obviously this is not great, since then the view tab is giving wrong information. Hence this PR also adds a small bit of code to update the speed text when the shortcuts are used.