### PR TITLE
Use same rotation matrix for coordinate transformations and render engine

### DIFF
--- a/WWTCore/WWTCore/Coordinates.cs
+++ b/WWTCore/WWTCore/Coordinates.cs
@@ -1386,18 +1386,18 @@ namespace TerraViewer
                                                + DMSToDegrees(0, 0, 2.45) * U10;
         }
 
-        static double[][] RotationMatrix = null;
+        public static double[][] GalacticRotationMatrix = null;
 
         public static double[] J2000toGalactic(double J2000RA, double J2000DEC)
         {
             double[] J2000pos = new double[] { Math.Cos(J2000RA / 180.0 * Math.PI) * Math.Cos(J2000DEC / 180.0 * Math.PI), Math.Sin(J2000RA / 180.0 * Math.PI) * Math.Cos(J2000DEC / 180.0 * Math.PI), Math.Sin(J2000DEC / 180.0 * Math.PI) };
 
-            if (RotationMatrix == null)
+            if (GalacticRotationMatrix == null)
             {
-                RotationMatrix = new double[3][];
-                RotationMatrix[0] = new double[] { -.0548755604, -.8734370902, -.4838350155 };
-                RotationMatrix[1] = new double[] { .4941094279, -.4448296300, .7469822445 };
-                RotationMatrix[2] = new double[] { -.8676661490, -.1980763734, .4559837762 };
+                GalacticRotationMatrix = new double[3][];
+                GalacticRotationMatrix[0] = new double[] { -.0548755604, -.8734370902, -.4838350155 };
+                GalacticRotationMatrix[1] = new double[] { .4941094279, -.4448296300, .7469822445 };
+                GalacticRotationMatrix[2] = new double[] { -.8676661490, -.1980763734, .4559837762 };
             }
 
 
@@ -1405,7 +1405,7 @@ namespace TerraViewer
             double[] Galacticpos = new double[3];
             for (int i = 0; i < 3; i++)
             {
-                Galacticpos[i] = J2000pos[0] * RotationMatrix[i][0] + J2000pos[1] * RotationMatrix[i][1] + J2000pos[2] * RotationMatrix[i][2];
+                Galacticpos[i] = J2000pos[0] * GalacticRotationMatrix[i][0] + J2000pos[1] * GalacticRotationMatrix[i][1] + J2000pos[2] * GalacticRotationMatrix[i][2];
             }
 
             double GalacticL2 = Math.Atan2(Galacticpos[1], Galacticpos[0]);
@@ -1429,18 +1429,18 @@ namespace TerraViewer
         public static double[] GalactictoJ2000(double GalacticL2, double GalacticB2)
         {
             double[] Galacticpos = new double[] { Math.Cos(GalacticL2 / 180.0 * Math.PI) * Math.Cos(GalacticB2 / 180.0 * Math.PI), Math.Sin(GalacticL2 / 180.0 * Math.PI) * Math.Cos(GalacticB2 / 180.0 * Math.PI), Math.Sin(GalacticB2 / 180.0 * Math.PI) };
-            if (RotationMatrix == null)
+            if (GalacticRotationMatrix == null)
             {
-                RotationMatrix = new double[3][];
-                RotationMatrix[0] = new double[] { -.0548755604, -.8734370902, -.4838350155 };
-                RotationMatrix[1] = new double[] { .4941094279, -.4448296300, .7469822445 };
-                RotationMatrix[2] = new double[] { -.8676661490, -.1980763734, .4559837762 };
+                GalacticRotationMatrix = new double[3][];
+                GalacticRotationMatrix[0] = new double[] { -.0548755604, -.8734370902, -.4838350155 };
+                GalacticRotationMatrix[1] = new double[] { .4941094279, -.4448296300, .7469822445 };
+                GalacticRotationMatrix[2] = new double[] { -.8676661490, -.1980763734, .4559837762 };
             }
 
             double[] J2000pos = new double[3];
             for (int i = 0; i < 3; i++)
             {
-                J2000pos[i] = Galacticpos[0] * RotationMatrix[0][i] + Galacticpos[1] * RotationMatrix[1][i] + Galacticpos[2] * RotationMatrix[2][i];
+                J2000pos[i] = Galacticpos[0] * GalacticRotationMatrix[0][i] + Galacticpos[1] * GalacticRotationMatrix[1][i] + Galacticpos[2] * GalacticRotationMatrix[2][i];
             }
 
             double J2000RA = Math.Atan2(J2000pos[1], J2000pos[0]);

--- a/WWTExplorer3d/Coordinates.cs
+++ b/WWTExplorer3d/Coordinates.cs
@@ -11,6 +11,23 @@ namespace TerraViewer
         const double RC = (Math.PI / 180.0);
         const double RCRA = (Math.PI / 12.0);
         const float radius = 1;
+
+        private static double[3][] _GalacticRotationMatrix = null;
+
+        public static double[3][] GalacticRotationMatrix {
+            get
+            {
+                if (_GalacticRotationMatrix == null)
+                {
+                    _GalacticRotationMatrix = new double[3][];
+                    _GalacticRotationMatrix[0] = new double[] { -.0548755604, -.8734370902, -.4838350155 };
+                    _GalacticRotationMatrix[1] = new double[] { .4941094279, -.4448296300, .7469822445 };
+                    _GalacticRotationMatrix[2] = new double[] { -.8676661490, -.1980763734, .4559837762 };
+                }
+                return _GalacticRotationMatrix;
+            }
+        }
+
         static public Vector3 GeoTo3d(double lat, double lng)
         {
             return new Vector3((float)(Math.Cos(lng * RC) * Math.Cos(lat * RC) * radius), (float)(Math.Sin(lat * RC) * radius), (float)(Math.Sin(lng * RC) * Math.Cos(lat * RC) * radius));
@@ -1451,26 +1468,14 @@ namespace TerraViewer
                                                + DMSToDegrees(0, 0, 2.45) * U10;
         }
 
-        static double[][] RotationMatrix = null;
-
         public static double[] J2000toGalactic(double J2000RA, double J2000DEC)
         {
             double[] J2000pos = new double[] { Math.Cos(J2000RA / 180.0 * Math.PI) * Math.Cos(J2000DEC / 180.0 * Math.PI), Math.Sin(J2000RA / 180.0 * Math.PI) * Math.Cos(J2000DEC / 180.0 * Math.PI), Math.Sin(J2000DEC / 180.0 * Math.PI) };
 
-            if (RotationMatrix == null)
-            {
-                RotationMatrix = new double[3][];
-                RotationMatrix[0] = new double[] { -.0548755604, -.8734370902, -.4838350155 };
-                RotationMatrix[1] = new double[] { .4941094279, -.4448296300, .7469822445 };
-                RotationMatrix[2] = new double[] { -.8676661490, -.1980763734, .4559837762 };
-            }
-
-
-
             double[] Galacticpos = new double[3];
             for (int i = 0; i < 3; i++)
             {
-                Galacticpos[i] = J2000pos[0] * RotationMatrix[i][0] + J2000pos[1] * RotationMatrix[i][1] + J2000pos[2] * RotationMatrix[i][2];
+                Galacticpos[i] = J2000pos[0] * Coordinates.GalacticRotationMatrix[i][0] + J2000pos[1] * Coordinates.GalacticRotationMatrix[i][1] + J2000pos[2] * Coordinates.GalacticRotationMatrix[i][2];
             }
 
             double GalacticL2 = Math.Atan2(Galacticpos[1], Galacticpos[0]);
@@ -1489,23 +1494,14 @@ namespace TerraViewer
         }
 
 
-
-
         public static double[] GalactictoJ2000(double GalacticL2, double GalacticB2)
         {
             double[] Galacticpos = new double[] { Math.Cos(GalacticL2 / 180.0 * Math.PI) * Math.Cos(GalacticB2 / 180.0 * Math.PI), Math.Sin(GalacticL2 / 180.0 * Math.PI) * Math.Cos(GalacticB2 / 180.0 * Math.PI), Math.Sin(GalacticB2 / 180.0 * Math.PI) };
-            if (RotationMatrix == null)
-            {
-                RotationMatrix = new double[3][];
-                RotationMatrix[0] = new double[] { -.0548755604, -.8734370902, -.4838350155 };
-                RotationMatrix[1] = new double[] { .4941094279, -.4448296300, .7469822445 };
-                RotationMatrix[2] = new double[] { -.8676661490, -.1980763734, .4559837762 };
-            }
 
             double[] J2000pos = new double[3];
             for (int i = 0; i < 3; i++)
             {
-                J2000pos[i] = Galacticpos[0] * RotationMatrix[0][i] + Galacticpos[1] * RotationMatrix[1][i] + Galacticpos[2] * RotationMatrix[2][i];
+                J2000pos[i] = Galacticpos[0] * GalacticRotationMatrix[0][i] + Galacticpos[1] * GalacticRotationMatrix[1][i] + Galacticpos[2] * GalacticRotationMatrix[2][i];
             }
 
             double J2000RA = Math.Atan2(J2000pos[1], J2000pos[0]);

--- a/WWTExplorer3d/RenderEngine.cs
+++ b/WWTExplorer3d/RenderEngine.cs
@@ -2134,6 +2134,31 @@ namespace TerraViewer
         bool galMatInit = false;
         Matrix3d galacticMatrix = Matrix3d.Identity;
 
+        private void SetupGalacticMatrix()
+        {
+            galacticMatrix = new Matrix3d(
+                -Coordinates.GalacticRotationMatrix[1][0],
+                -Coordinates.GalacticRotationMatrix[2][0],
+                Coordinates.GalacticRotationMatrix[0][0],
+                0,
+
+                Coordinates.GalacticRotationMatrix[1][2],
+                Coordinates.GalacticRotationMatrix[2][2],
+                -Coordinates.GalacticRotationMatrix[0][2],
+                0,
+
+                -Coordinates.GalacticRotationMatrix[1][1],
+                -Coordinates.GalacticRotationMatrix[2][1],
+                Coordinates.GalacticRotationMatrix[0][1],
+                0,
+
+                0, 0, 0, 1
+            );
+            galMatInit = true;
+        }
+
+
+
         private void SetupMatricesSpace11(double localZoomFactor, RenderTypes renderType )
         {
             //todo uwp do we user MultiChannel for MR Headset?
@@ -2147,16 +2172,10 @@ namespace TerraViewer
 
             if ((Settings.Active.GalacticMode && !Settings.Active.LocalHorizonMode) && currentImageSetfield.DataSetType == ImageSetType.Sky)
             {
-                // Show in galactic coordinates
                 if (!galMatInit)
                 {
-                    galacticMatrix = Matrix3d.Identity;
-                    galacticMatrix.Multiply(Matrix3d.RotationY(-(90 - (17.7603329867975 * 15)) / 180.0 * Math.PI));
-                    galacticMatrix.Multiply(Matrix3d.RotationX(-((-28.9361739586894)) / 180.0 * Math.PI));
-                    galacticMatrix.Multiply(Matrix3d.RotationZ(((31.422052860102041270114993238783) - 90) / 180.0 * Math.PI));
-                    galMatInit = true;
+                    SetupGalacticMatrix();
                 }
-
                 WorldMatrix = galacticMatrix;
                 WorldMatrix.Multiply(Matrix3d.RotationY(((az)) / 180.0 * Math.PI));
                 WorldMatrix.Multiply(Matrix3d.RotationX(-((alt)) / 180.0 * Math.PI));
@@ -2405,13 +2424,8 @@ namespace TerraViewer
             {
                 if (!galMatInit)
                 {
-                    galacticMatrix = Matrix3d.Identity;
-                    galacticMatrix.Multiply(Matrix3d.RotationY(-(90 - (17.7603329867975 * 15)) / 180.0 * Math.PI));
-                    galacticMatrix.Multiply(Matrix3d.RotationX(-((-28.9361739586894)) / 180.0 * Math.PI));
-                    galacticMatrix.Multiply(Matrix3d.RotationZ(((31.422052860102041270114993238783) - 90) / 180.0 * Math.PI));
-                    galMatInit = true;
+                    SetupGalacticMatrix();
                 }
-
                 WorldMatrix = galacticMatrix;
                 WorldMatrix.Multiply(Matrix3d.RotationY(((az)) / 180.0 * Math.PI));
                 WorldMatrix.Multiply(Matrix3d.RotationX(-((alt)) / 180.0 * Math.PI));
@@ -3918,13 +3932,8 @@ namespace TerraViewer
             {
                 if (!galMatInit)
                 {
-                    galacticMatrix = Matrix3d.Identity;
-                    galacticMatrix.Multiply(Matrix3d.RotationY(-(90 - (17.7603329867975 * 15)) / 180.0 * Math.PI));
-                    galacticMatrix.Multiply(Matrix3d.RotationX(-((-28.9361739586894)) / 180.0 * Math.PI));
-                    galacticMatrix.Multiply(Matrix3d.RotationZ(((31.422052860102041270114993238783) - 90) / 180.0 * Math.PI));
-                    galMatInit = true;
+                    SetupGalacticMatrix();
                 }
-
                 WorldMatrix = galacticMatrix;
                 WorldMatrix.Multiply(Matrix3d.RotationY(((az)) / 180.0 * Math.PI));
                 WorldMatrix.Multiply(Matrix3d.RotationX(-((alt)) / 180.0 * Math.PI));


### PR DESCRIPTION
This is the Windows client companion to https://github.com/WorldWideTelescope/wwt-webgl-engine/pull/416, as the Windows client has the same problem described in https://github.com/WorldWideTelescope/wwt-webgl-engine/issues/415.